### PR TITLE
Upgrade helm-oci-chart-releaser to v0.3.0

### DIFF
--- a/.github/workflows/publish-and-release.yaml
+++ b/.github/workflows/publish-and-release.yaml
@@ -136,7 +136,7 @@ jobs:
           sed -i 's/version: \(.*\)/version: \1-${{ env.VERSION }}/g' charts/ephemeral/Chart.yaml
           sed -i 's/tag: latest/tag: ${{ env.VERSION }}/g' charts/ephemeral/values.yaml
       - name: Push Helm Chart
-        uses: appany/helm-oci-chart-releaser@v0.2.0
+        uses: appany/helm-oci-chart-releaser@v0.3.0
         with:
           name: ephemeral
           repository: carbynestack


### PR DESCRIPTION
Required since Helm 3.7.0 broke former version 0.2.0. This was resolved with appany/helm-oci-chart-releaser#4

Signed-off-by: Sebastian Becker <sebastian.becker@de.bosch.com>