### PR TITLE
enhance ephemeral to work with more than 2 players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ cover.*
 
 ### Ko
 /_docker_build_files/*
+vendor
+pkg/mod/
+pkg/sumdb/

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -17,6 +17,12 @@ these files remains with the original authors.
 
 > **NOTE**: Please keep the following list of contributors sorted.
 
+### Honda Research Institute Europe GmbH
+
+- Graf Johannes (synyx) [info@honda-ri.de](mailto:info@honda-ri.de)
+- Klenk Timo (synyx) [info@honda-ri.de](mailto:info@honda-ri.de)
+- Scherer Petra (synyx) [info@honda-ri.de](mailto:info@honda-ri.de)
+
 ### Robert Bosch GmbH
 
 - Becker Sebastian <sebastian.becker@de.bosch.com>

--- a/charts/ephemeral/README.md
+++ b/charts/ephemeral/README.md
@@ -77,6 +77,12 @@ provided while installing the chart. For example,
 helm install --name my-release -f values.yaml ephemeral
 ```
 
+### Global Parameters
+
+| Parameter     | Description       | Default |
+| ------------- | ----------------- | ------- |
+| `playerCount` | Number of players | `2`     |
+
 ### Discovery Service
 
 | Parameter                       | Description                                                  | Default                            |
@@ -88,7 +94,6 @@ helm install --name my-release -f values.yaml ephemeral
 | `discovery.service.annotations` | Annotations that should be attached to the Discovery service | `[]`                               |
 | `discovery.frontendUrl`         | The external base URL of the VCP                             | \`\`                               |
 | `discovery.master.port`         | The port of the master discovery service instance            | \`\`                               |
-| `discovery.playerCount`         | Number of players                                            | `2`                                |
 
 ### Network Controller
 
@@ -118,4 +123,3 @@ helm install --name my-release -f values.yaml ephemeral
 | `ephemeral.frontendUrl`               | The external base URL of the VCP                             | \`\`                               |
 | `ephemeral.spdz.prime`                | The prime used by SPDZ                                       | \`\`                               |
 | `ephemeral.playerId`                  | Id of this player                                            | \`\`                               |
-| `ephemeral.playerCount`               | Number of players                                            | `2`                                |

--- a/charts/ephemeral/README.md
+++ b/charts/ephemeral/README.md
@@ -88,6 +88,7 @@ helm install --name my-release -f values.yaml ephemeral
 | `discovery.service.annotations` | Annotations that should be attached to the Discovery service | `[]`                               |
 | `discovery.frontendUrl`         | The external base URL of the VCP                             | \`\`                               |
 | `discovery.master.port`         | The port of the master discovery service instance            | \`\`                               |
+| `discovery.playerCount`         | Number of players                                            | `2`                                |
 
 ### Network Controller
 
@@ -116,3 +117,5 @@ helm install --name my-release -f values.yaml ephemeral
 | `ephemeral.amphora.path`              | The path under which the Amphora serivce is available        | `/`                                |
 | `ephemeral.frontendUrl`               | The external base URL of the VCP                             | \`\`                               |
 | `ephemeral.spdz.prime`                | The prime used by SPDZ                                       | \`\`                               |
+| `ephemeral.playerId`                  | Id of this player                                            | \`\`                               |
+| `ephemeral.playerCount`               | Number of players                                            | `2`                                |

--- a/charts/ephemeral/templates/discovery.yaml
+++ b/charts/ephemeral/templates/discovery.yaml
@@ -75,7 +75,7 @@ data:
       "masterHost": "{{ .Values.discovery.master.host }}",
       "masterPort": "{{ .Values.discovery.master.port }}",
       "slave": {{ if .Values.discovery.isMaster }}false{{ else }}true{{ end }},
-      "playerCount": {{ .Values.discovery.playerCount }}
+      "playerCount": {{ .Values.playerCount }}
     }
 ---
 apiVersion: networking.istio.io/v1alpha3

--- a/charts/ephemeral/templates/discovery.yaml
+++ b/charts/ephemeral/templates/discovery.yaml
@@ -74,7 +74,8 @@ data:
       "frontendURL": "{{ .Values.discovery.frontendUrl }}",
       "masterHost": "{{ .Values.discovery.master.host }}",
       "masterPort": "{{ .Values.discovery.master.port }}",
-      "slave": {{ if .Values.discovery.isMaster }}false{{ else }}true{{ end }}
+      "slave": {{ if .Values.discovery.isMaster }}false{{ else }}true{{ end }},
+      "playerCount": {{ .Values.discovery.playerCount }}
     }
 ---
 apiVersion: networking.istio.io/v1alpha3

--- a/charts/ephemeral/templates/ephemeral.yaml
+++ b/charts/ephemeral/templates/ephemeral.yaml
@@ -29,13 +29,6 @@ spec:
         - name: "{{ .Chart.Name }}-ephemeral"
           image: "{{ .Values.ephemeral.image.registry }}/{{ .Values.ephemeral.image.repository }}:{{ .Values.ephemeral.image.tag }}"
           imagePullPolicy: {{ .Values.ephemeral.image.pullPolicy }}
-          {{- if .Values.ephemeral.env }}
-          env:
-          {{- range .Values.ephemeral.env }}
-          - name: {{ .name }}
-            value: {{ .value | quote}}
-          {{- end }}
-          {{- end }}
           ports:
             - name: http1
               containerPort: 8080

--- a/charts/ephemeral/templates/ephemeral.yaml
+++ b/charts/ephemeral/templates/ephemeral.yaml
@@ -83,5 +83,5 @@ data:
       "frontendURL": "{{ .Values.ephemeral.frontendUrl }}",
       "discoveryAddress": "{{ .Values.ephemeral.discoveryAddress }}",
       "playerID": {{ .Values.ephemeral.playerId }},
-      "playerCount": {{ .Values.ephemeral.playerCount }}
+      "playerCount": {{ .Values.playerCount }}
     }

--- a/charts/ephemeral/templates/ephemeral.yaml
+++ b/charts/ephemeral/templates/ephemeral.yaml
@@ -29,6 +29,13 @@ spec:
         - name: "{{ .Chart.Name }}-ephemeral"
           image: "{{ .Values.ephemeral.image.registry }}/{{ .Values.ephemeral.image.repository }}:{{ .Values.ephemeral.image.tag }}"
           imagePullPolicy: {{ .Values.ephemeral.image.pullPolicy }}
+          {{- if .Values.ephemeral.env }}
+          env:
+          {{- range .Values.ephemeral.env }}
+          - name: {{ .name }}
+            value: {{ .value | quote}}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http1
               containerPort: 8080
@@ -82,5 +89,6 @@ data:
       },
       "frontendURL": "{{ .Values.ephemeral.frontendUrl }}",
       "discoveryAddress": "{{ .Values.ephemeral.discoveryAddress }}",
-      "playerID": {{ .Values.ephemeral.playerId }}
+      "playerID": {{ .Values.ephemeral.playerId }},
+      "playerCount": {{ .Values.ephemeral.playerCount }}
     }

--- a/charts/ephemeral/values.yaml
+++ b/charts/ephemeral/values.yaml
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+playerCount: 2
+
 # This file defines the default values for all variables used in the Ephemeral Helm Chart.
 discovery:
   service:
@@ -20,8 +22,6 @@ discovery:
   master:
     host:
     port:
-  # make sure using same value for ephemeral!
-  playerCount: 2
 
 ephemeral:
   service:
@@ -46,8 +46,6 @@ ephemeral:
   frontendUrl:
   discoveryAddress: discovery.default.svc.cluster.local
   playerId:
-  # make sure using same value for discovery!
-  playerCount: 2
   spdz:
     prime:
     rInv:

--- a/charts/ephemeral/values.yaml
+++ b/charts/ephemeral/values.yaml
@@ -51,7 +51,6 @@ ephemeral:
   spdz:
     prime:
     rInv:
-  env: []
 
 networkController:
   image:

--- a/charts/ephemeral/values.yaml
+++ b/charts/ephemeral/values.yaml
@@ -20,6 +20,8 @@ discovery:
   master:
     host:
     port:
+  # make sure using same value for ephemeral!
+  playerCount: 2
 
 ephemeral:
   service:
@@ -44,9 +46,12 @@ ephemeral:
   frontendUrl:
   discoveryAddress: discovery.default.svc.cluster.local
   playerId:
+  # make sure using same value for discovery!
+  playerCount: 2
   spdz:
     prime:
     rInv:
+  env: []
 
 networkController:
   image:

--- a/charts/ephemeral/values.yaml
+++ b/charts/ephemeral/values.yaml
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# This file defines the default values for all variables used in the Ephemeral Helm Chart.
 playerCount: 2
 
-# This file defines the default values for all variables used in the Ephemeral Helm Chart.
 discovery:
   service:
     annotations: []

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -95,7 +95,7 @@ func NewClient(config *types.DiscoveryConfig, stateTimeout time.Duration, logger
 	mode := ModeMaster
 	client := &cl.Client{}
 	var err error
-	if config.Slave { //If Starbuck -> Open GRPc Connection to Master (Apollo)
+	if config.Slave { // If Follower/Slave -> Open GRPc Connection to Master (Apollo)
 		inCh := make(chan *proto.Event)
 		outCh := make(chan *proto.Event)
 		grpcClientConf := &c.TransportClientConfig{

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -68,7 +68,7 @@ func main() {
 		panic(err)
 	}
 	// TODO: extract this Istio address dynamically.
-	s := discovery.NewServiceNG(bus, pb, stateTimeout, tr, n, config.FrontendURL, logger, mode, client)
+	s := discovery.NewServiceNG(bus, pb, stateTimeout, tr, n, config.FrontendURL, logger, mode, client, config.PlayerCount)
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +95,7 @@ func NewClient(config *types.DiscoveryConfig, stateTimeout time.Duration, logger
 	mode := ModeMaster
 	client := &cl.Client{}
 	var err error
-	if config.Slave {
+	if config.Slave { //If Starbuck -> Open GRPc Connection to Master (Apollo)
 		inCh := make(chan *proto.Event)
 		outCh := make(chan *proto.Event)
 		grpcClientConf := &c.TransportClientConfig{
@@ -166,6 +166,9 @@ func ParseConfig(path string) (*DiscoveryConfig, error) {
 	}
 	if conf.MasterPort == "" {
 		return nil, errors.New("missing config error, MasterPort must be defined")
+	}
+	if conf.PlayerCount == 0 {
+		return nil, errors.New("missing config error, PlayerCount must be defined")
 	}
 	return &conf, nil
 }

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -95,7 +95,7 @@ func NewClient(config *types.DiscoveryConfig, stateTimeout time.Duration, logger
 	mode := ModeMaster
 	client := &cl.Client{}
 	var err error
-	if config.Slave { // If Follower/Slave -> Open GRPc Connection to Master (Apollo)
+	if config.Slave { // If Follower/Slave -> Open GRPc Connection to Master
 		inCh := make(chan *proto.Event)
 		outCh := make(chan *proto.Event)
 		grpcClientConf := &c.TransportClientConfig{

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -170,6 +170,9 @@ func ParseConfig(path string) (*DiscoveryConfig, error) {
 	if conf.PlayerCount == 0 {
 		return nil, errors.New("missing config error, PlayerCount must be defined")
 	}
+	if conf.PlayerCount < 2 {
+		return nil, errors.New("invalid config error, PlayerCount must be 2 or higher")
+	}
 	return &conf, nil
 }
 

--- a/cmd/discovery/main_test.go
+++ b/cmd/discovery/main_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Main", func() {
 			FrontendURL: "abc",
 			MasterHost:  "abc",
 			MasterPort:  "8080",
+			PlayerCount: 2,
 		}
 		logger := zap.NewNop().Sugar()
 		errCh := make(chan error)
@@ -57,12 +58,12 @@ var _ = Describe("Main", func() {
 		})
 		Context("all required parameters are specified", func() {
 			AfterEach(func() {
-				_, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
+				_, _, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("succeeds", func() {
 				data := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud",
-		"masterPort": "31400","slave": false}`)
+		"masterPort": "31400","slave": false, "playerCount": 2}`)
 				err := ioutil.WriteFile(path, data, 0644)
 				Expect(err).NotTo(HaveOccurred())
 				conf, err := ParseConfig(path)
@@ -76,35 +77,41 @@ var _ = Describe("Main", func() {
 		Context("one of the required parameters is missing", func() {
 			Context("when no frontendURL is defined", func() {
 				AfterEach(func() {
-					_, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
+					_, _, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
 					Expect(err).NotTo(HaveOccurred())
 				})
 				It("returns an error", func() {
 					path := fmt.Sprintf("/tmp/test-%d", random)
 					noFrontendURLConfig := []byte(`{"masterHost": "apollo.test.specs.cloud",
-			"masterPort": "31400","slave": false}`)
+			"masterPort": "31400","slave": false, "playerCount": 2}`)
 					err := ioutil.WriteFile(path, noFrontendURLConfig, 0644)
 					Expect(err).NotTo(HaveOccurred())
 					_, err = ParseConfig(path)
 					Expect(err).To(HaveOccurred())
 
 					noMasterHostConfigSlave := []byte(`{"frontendURL": "apollo.test.specs.cloud",
-					"masterPort": "31400","slave": true}`)
+					"masterPort": "31400","slave": true, "playerCount": 2}`)
 					err = ioutil.WriteFile(path, noMasterHostConfigSlave, 0644)
 					Expect(err).NotTo(HaveOccurred())
 					_, err = ParseConfig(path)
 					Expect(err).To(HaveOccurred())
 
 					noMasterHostConfigMaster := []byte(`{"frontendURL": "apollo.test.specs.cloud",
-					"masterPort": "31400","slave": false}`)
+					"masterPort": "31400","slave": false, "playerCount": 2}`)
 					err = ioutil.WriteFile(path, noMasterHostConfigMaster, 0644)
 					Expect(err).NotTo(HaveOccurred())
 					conf, err := ParseConfig(path)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(conf).NotTo(BeNil())
 
-					noMasterPortConfigSlave := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud","slave": false}`)
+					noMasterPortConfigSlave := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud","slave": false, "playerCount": 2}`)
 					err = ioutil.WriteFile(path, noMasterPortConfigSlave, 0644)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = ParseConfig(path)
+					Expect(err).To(HaveOccurred())
+
+					noPlayerCountConfig := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud","slave": false, "masterPort": "31400"}`)
+					err = ioutil.WriteFile(path, noPlayerCountConfig, 0644)
 					Expect(err).NotTo(HaveOccurred())
 					_, err = ParseConfig(path)
 					Expect(err).To(HaveOccurred())

--- a/cmd/discovery/main_test.go
+++ b/cmd/discovery/main_test.go
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-package main_test
+package main
 
 import (
 	"errors"
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 
-	. "github.com/carbynestack/ephemeral/cmd/discovery"
 	"github.com/carbynestack/ephemeral/pkg/discovery"
 	. "github.com/carbynestack/ephemeral/pkg/types"
 	"github.com/carbynestack/ephemeral/pkg/utils"
@@ -177,6 +176,40 @@ var _ = Describe("Main", func() {
 					RunDeletion(doneCh, errCh, logger, s)
 				}
 				runDeletion()
+			})
+		})
+	})
+
+	Context("when getting the stateTimeout", func() {
+		Context("no stateTimeout was provided in the config", func() {
+			It("will use the defaultStateTimeout", func() {
+				var config = &DiscoveryConfig{}
+				timeout, err := getStateTimeout(config)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(timeout).To(Equal(defaultStateTimeout))
+			})
+		})
+		Context("an empty stateTimeout was provided in the config", func() {
+			It("will use the defaultStateTimeout", func() {
+				var config = &DiscoveryConfig{StateTimeout: ""}
+				timeout, err := getStateTimeout(config)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(timeout).To(Equal(defaultStateTimeout))
+			})
+		})
+		Context("a valid stateTimeout was provided in the config", func() {
+			It("will use the provided stateTimeout", func() {
+				var config = &DiscoveryConfig{StateTimeout: "5m"}
+				timeout, err := getStateTimeout(config)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(timeout).To(Equal(5 * time.Minute))
+			})
+		})
+		Context("an invalid stateTimeout was provided in the config", func() {
+			It("will return an error", func() {
+				var config = &DiscoveryConfig{StateTimeout: "invalid"}
+				_, err := getStateTimeout(config)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/cmd/discovery/main_test.go
+++ b/cmd/discovery/main_test.go
@@ -61,18 +61,42 @@ var _ = Describe("Main", func() {
 				_, _, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
 				Expect(err).NotTo(HaveOccurred())
 			})
-			It("succeeds", func() {
-				data := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud",
+			Context("parameters are plausible", func() {
+				It("succeeds", func() {
+					data := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud",
 		"masterPort": "31400","slave": false, "playerCount": 2}`)
-				err := ioutil.WriteFile(path, data, 0644)
-				Expect(err).NotTo(HaveOccurred())
-				conf, err := ParseConfig(path)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(conf.FrontendURL).To(Equal("apollo.test.specs.cloud"))
-				Expect(conf.MasterHost).To(Equal("apollo.test.specs.cloud"))
-				Expect(conf.MasterPort).To(Equal("31400"))
-				Expect(conf.Slave).To(BeFalse())
+					err := ioutil.WriteFile(path, data, 0644)
+					Expect(err).NotTo(HaveOccurred())
+					conf, err := ParseConfig(path)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(conf.FrontendURL).To(Equal("apollo.test.specs.cloud"))
+					Expect(conf.MasterHost).To(Equal("apollo.test.specs.cloud"))
+					Expect(conf.MasterPort).To(Equal("31400"))
+					Expect(conf.Slave).To(BeFalse())
+				})
 			})
+
+			Context("parameters are invalid", func() {
+				Context("playerCount is invalid", func() {
+					It("returns an error on PlayerCount == 1", func() {
+						data := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud",
+		"masterPort": "31400","slave": false, "playerCount": 1}`)
+						err := ioutil.WriteFile(path, data, 0644)
+						Expect(err).NotTo(HaveOccurred())
+						_, err = ParseConfig(path)
+						Expect(err).To(HaveOccurred())
+					})
+					It("returns an error on negative PlayerCount", func() {
+						data := []byte(`{"frontendURL": "apollo.test.specs.cloud","masterHost": "apollo.test.specs.cloud",
+		"masterPort": "31400","slave": false, "playerCount": -2}`)
+						err := ioutil.WriteFile(path, data, 0644)
+						Expect(err).NotTo(HaveOccurred())
+						_, err = ParseConfig(path)
+						Expect(err).To(HaveOccurred())
+					})
+				})
+			})
+
 		})
 		Context("one of the required parameters is missing", func() {
 			Context("when no frontendURL is defined", func() {

--- a/cmd/ephemeral/main.go
+++ b/cmd/ephemeral/main.go
@@ -62,6 +62,11 @@ func GetHandlerChain(conf *SPDZEngineConfig, logger *zap.SugaredLogger) (http.Ha
 	spdzClient := NewSPDZEngine(logger, utils.NewCommander(), typedConfig)
 	server := NewServer(spdzClient.Compile, spdzClient.Activate, logger, typedConfig)
 	activationHandler := http.HandlerFunc(server.ActivationHandler)
+	// Apply in Order:
+	// 1) MethodFilter: Check that only POST Requests can go through
+	// 2) BodyFilter: Check that Request Body is set properly and Sets the CtxConfig to the request
+	// 3) CompilationHandler: Compiles the script if ?compile=true
+	// 4) ActivationHandler: Runs the script
 	filterChain := server.MethodFilter(server.BodyFilter(server.CompilationHandler(activationHandler)))
 	return filterChain, nil
 }
@@ -118,6 +123,7 @@ func InitTypedConfig(conf *SPDZEngineConfig) (*SPDZEngineTypedConfig, error) {
 		RInv:             rInv,
 		AmphoraClient:    client,
 		PlayerID:         conf.PlayerID,
+		PlayerCount:      conf.PlayerCount,
 		FrontendURL:      conf.FrontendURL,
 		MaxBulkSize:      conf.MaxBulkSize,
 		DiscoveryAddress: conf.DiscoveryAddress,

--- a/cmd/ephemeral/main_test.go
+++ b/cmd/ephemeral/main_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Main", func() {
 					path = fmt.Sprintf("/tmp/test-%d", random)
 				})
 				AfterEach(func() {
-					_, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
+					_, _, err := cmder.CallCMD([]string{fmt.Sprintf("rm %s", path)}, "./")
 					Expect(err).NotTo(HaveOccurred())
 				})
 				Context("when it succeeds", func() {

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -132,7 +132,7 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 				WaitDoneOrTimeout(done)
 			})
 		})
-		Context("a single player sends multiple messages in a row", func() {
+		Context("a single player sends 2 messages in a row", func() {
 			It("doesn't create the second network", func() {
 				playersReady := GenerateEvents(PlayersReady, "0")[0]
 				playerOneIsReady := GenerateEvents(PlayerReady, "0")[0]

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -23,6 +23,11 @@ import (
 )
 
 var _ = Describe("DiscoveryNG", func() {
+	generateDiscoveryNGTestsWithPlayerCount(2)
+	generateDiscoveryNGTestsWithPlayerCount(5)
+})
+
+func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 
 	var (
 		bus             mb.MessageBus
@@ -36,7 +41,6 @@ var _ = Describe("DiscoveryNG", func() {
 		n               *FakeNetworker
 		frontendAddress string
 		logger          = zap.NewNop().Sugar()
-		playerCount     int
 	)
 
 	BeforeEach(func() {
@@ -53,7 +57,6 @@ var _ = Describe("DiscoveryNG", func() {
 		}
 		frontendAddress = "192.168.0.1"
 		conf := &FakeDClient{}
-		playerCount = 5
 		s = NewServiceNG(bus, pb, stateTimeout, tr, n, frontendAddress, logger, ModeMaster, conf, playerCount)
 		g = &GamesWithBus{
 			Games: s.games,
@@ -377,7 +380,7 @@ var _ = Describe("DiscoveryNG", func() {
 			WaitDoneOrTimeout(done)
 		})
 	})
-})
+}
 
 func createPlayersAndPlayerReadyEvents(playerCount int, frontendAddress string) ([]*proto.Player, []*proto.Event) {
 	allPlayers := make([]*proto.Player, playerCount)

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -51,7 +51,8 @@ var _ = Describe("DiscoveryNG", func() {
 		}
 		frontendAddress = "192.168.0.1"
 		conf := &FakeDClient{}
-		s = NewServiceNG(bus, pb, stateTimeout, tr, n, frontendAddress, logger, ModeMaster, conf)
+		playerCount := 2
+		s = NewServiceNG(bus, pb, stateTimeout, tr, n, frontendAddress, logger, ModeMaster, conf, playerCount)
 		g = &GamesWithBus{
 			Games: s.games,
 			Bus:   bus,

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -80,23 +80,18 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 				for i := 0; i < playerCount; i++ {
 					pb.PublishExternalEvent(ev, ClientIncomingEventsTopic)
 				}
-
 				WaitDoneOrTimeout(done)
 			})
 			It("receives addresses of the players that joined the game", func() {
 				playersReady := GenerateEvents(PlayersReady, "0")[0]
-
 				_, allPlayerReadyEvents := createPlayersAndPlayerReadyEvents(playerCount, frontendAddress)
-
 				assertExternalEventBody(playersReady, ClientOutgoingEventsTopic, g, done, func(event *proto.Event) {
 					Expect(len(event.Players)).To(Equal(playerCount))
 					for i := 0; i < playerCount; i++ {
 						Expect(event.Players[i].Ip).To(Equal(frontendAddress))
 						Expect(event.Players[i].Port).NotTo(BeZero())
 					}
-
 					Expect(len(s.pods)).To(Equal(playerCount))
-
 					for i := 0; i < playerCount; i++ {
 						podName := fmt.Sprintf("pod%d", i+1)
 						Expect(s.pods[podName]).To(Equal(int32(i)))
@@ -104,7 +99,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 				})
 				go s.Start()
 				s.WaitUntilReady(timeout)
-
 				for _, playerReadyEvent := range allPlayerReadyEvents {
 					pb.PublishExternalEvent(playerReadyEvent, ClientIncomingEventsTopic)
 				}
@@ -113,13 +107,9 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 
 			It("doesn't create the player twice", func() {
 				playersReady := GenerateEvents(PlayersReady, "0")[0]
-
 				allPlayers, allPlayerReadyEvents := createPlayersAndPlayerReadyEvents(playerCount, frontendAddress)
-
 				playerOneTCPCheckSuccess := GenerateEvents(TCPCheckSuccess, "0")[0]
-
 				playerOneTCPCheckSuccess.Players[0] = allPlayers[0]
-
 				assertExternalEventBody(playersReady, ClientOutgoingEventsTopic, g, done, func(event *proto.Event) {
 					Expect(len(event.Players)).To(Equal(playerCount))
 				})
@@ -136,7 +126,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 			It("doesn't create the second network", func() {
 				playersReady := GenerateEvents(PlayersReady, "0")[0]
 				playerOneIsReady := GenerateEvents(PlayerReady, "0")[0]
-
 				player1 := proto.Player{
 					Ip: frontendAddress,
 					Id: 0,
@@ -147,7 +136,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 				})
 				go s.Start()
 				s.WaitUntilReady(timeout)
-
 				for i := 0; i < playerCount; i++ {
 					// ToDo: Isn't it an error if the same player sends its ReadyMessage multiple times?
 					//    Or rather, should we in such a case really go to PlayersReady?
@@ -183,15 +171,12 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 			It("it uses the existing network configuration", func() {
 				playersReady := GenerateEvents(PlayersReady, "0")[0]
 				playersReady1 := GenerateEvents(PlayersReady, "1")[0]
-
 				allPlayers, allPlayerReadyEventsInGame0 := createPlayersAndPlayerReadyEvents(playerCount, frontendAddress)
 				allPlayerReadyEventsInGame1 := make([]*proto.Event, playerCount)
-
 				for i := 0; i < playerCount; i++ {
 					allPlayerReadyEventsInGame1[i] = GenerateEvents(PlayerReady, "1")[0]
 					allPlayerReadyEventsInGame1[i].Players[0] = allPlayers[i]
 				}
-
 				assertExternalEventBody(playersReady, ClientOutgoingEventsTopic, g, done, func(event *proto.Event) {
 					pp, _ := s.players["0"]
 					for i := 0; i < playerCount; i++ {
@@ -254,7 +239,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 				})
 				go s.Start()
 				s.WaitUntilReady(timeout)
-
 				gameIds := make([]string, 2*playerCount)
 				for i := 0; i < playerCount; i++ {
 					gameIds[i] = "0"
@@ -284,7 +268,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 			ready = GenerateEvents(PlayerReady, "0")[0]
 			tcpCheckSuccess = GenerateEvents(TCPCheckSuccess, "0")[0]
 			gameFinishedWithSuccess = GenerateEvents(GameFinishedWithSuccess, "0")[0]
-
 			playersReady = GenerateEvents(PlayersReady, "0")[0]
 			tcpCheckSuccessAll = GenerateEvents(TCPCheckSuccessAll, "0")[0]
 			gameProtocolError = GenerateEvents(GameProtocolError, "0")[0]
@@ -297,7 +280,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 
 			go s.Start()
 			s.WaitUntilReady(timeout)
-
 			for i := 0; i < playerCount; i++ {
 				pb.PublishExternalEvent(ready, ClientIncomingEventsTopic)
 			}
@@ -326,7 +308,6 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 
 			go s.Start()
 			s.WaitUntilReady(timeout)
-
 			for i := 0; i < playerCount; i++ {
 				pb.PublishExternalEvent(ready, ClientIncomingEventsTopic)
 			}
@@ -338,14 +319,12 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 			for i := 0; i < playerCount; i++ {
 				pb.PublishExternalEvent(gameFinishedWithSuccess, ClientIncomingEventsTopic)
 			}
-
 			WaitDoneOrTimeout(done)
 
 			// Try to play the game with the same id again and see that it returns an error.
 			assertExternalEvent(gameProtocolError, ClientOutgoingEventsTopic, g, done, func(states []string) {
 			})
 			pb.PublishExternalEvent(ready, ClientIncomingEventsTopic)
-
 			WaitDoneOrTimeout(done)
 		})
 	})
@@ -385,14 +364,12 @@ func generateDiscoveryNGTestsWithPlayerCount(playerCount int) {
 func createPlayersAndPlayerReadyEvents(playerCount int, frontendAddress string) ([]*proto.Player, []*proto.Event) {
 	allPlayers := make([]*proto.Player, playerCount)
 	allPlayerReadyEvents := make([]*proto.Event, playerCount)
-
 	for i := 0; i < playerCount; i++ {
 		allPlayers[i] = &proto.Player{
 			Ip:  frontendAddress,
 			Id:  int32(i),
 			Pod: fmt.Sprintf("pod%d", i+1),
 		}
-
 		allPlayerReadyEvents[i] = GenerateEvents(PlayerReady, "0")[0]
 		allPlayerReadyEvents[i].Players[0] = allPlayers[i]
 	}

--- a/pkg/discovery/game.go
+++ b/pkg/discovery/game.go
@@ -51,9 +51,7 @@ func (g *Game) Bus() mb.MessageBus {
 }
 
 // NewGame returns an instance of Game.
-func NewGame(ctx context.Context, id string, bus mb.MessageBus, timeout time.Duration, logger *zap.SugaredLogger) (*Game, error) {
-	// TODO: read this parameter from the Game.
-	players := 2
+func NewGame(ctx context.Context, id string, bus mb.MessageBus, timeout time.Duration, logger *zap.SugaredLogger, playerCount int) (*Game, error) {
 	publisher := &Publisher{
 		Bus: bus,
 	}
@@ -63,9 +61,9 @@ func NewGame(ctx context.Context, id string, bus mb.MessageBus, timeout time.Dur
 	}
 	cb := []*fsm.Callback{
 		fsm.AfterEnter(WaitPlayersReady).Do(callbacker.sendRegistered()),
-		fsm.AfterEnter(WaitPlayersReady).Do(callbacker.checkSomethingReady(players, PlayerReady, PlayersReady)),
-		fsm.AfterEnter(WaitTCPCheck).Do(callbacker.checkSomethingReady(players, TCPCheckSuccess, TCPCheckSuccessAll)),
-		fsm.AfterEnter(Playing).Do(callbacker.checkSomethingReady(players, GameFinishedWithSuccess, GameSuccess)),
+		fsm.AfterEnter(WaitPlayersReady).Do(callbacker.checkSomethingReady(playerCount, PlayerReady, PlayersReady)),
+		fsm.AfterEnter(WaitTCPCheck).Do(callbacker.checkSomethingReady(playerCount, TCPCheckSuccess, TCPCheckSuccessAll)),
+		fsm.AfterEnter(Playing).Do(callbacker.checkSomethingReady(playerCount, GameFinishedWithSuccess, GameSuccess)),
 		fsm.AfterEnter(GameDone).Do(callbacker.gameDone()),
 		fsm.AfterEnter(GameError).Do(callbacker.gameError()),
 		fsm.WhenStateTimeout().Do(callbacker.stateTimeout()),

--- a/pkg/discovery/game_test.go
+++ b/pkg/discovery/game_test.go
@@ -23,20 +23,22 @@ var _ = Describe("Game", func() {
 		done chan struct{}
 		bus  mb.MessageBus
 
-		timeout time.Duration
-		gameID  string
-		game    *Game
-		pb      Publisher
-		errCh   chan error
-		logger  = zap.NewNop().Sugar()
-		ctx     = context.TODO()
+		timeout     time.Duration
+		gameID      string
+		game        *Game
+		playerCount int
+		pb          Publisher
+		errCh       chan error
+		logger      = zap.NewNop().Sugar()
+		ctx         = context.TODO()
 	)
 	BeforeEach(func() {
 		done = make(chan struct{})
 		bus = mb.New(10000)
 		timeout = 10 * time.Second
 		gameID = "0"
-		game, _ = NewGame(ctx, gameID, bus, timeout, logger)
+		playerCount = 2
+		game, _ = NewGame(ctx, gameID, bus, timeout, logger, playerCount)
 		pb = Publisher{
 			Bus: bus,
 			Fsm: game.fsm,
@@ -130,7 +132,7 @@ var _ = Describe("Game", func() {
 	Context("state timeout occurs", func() {
 		It("transitions to the GameError state", func() {
 			timeout := 10 * time.Millisecond
-			game, _ := NewGame(ctx, gameID, bus, timeout, logger)
+			game, _ := NewGame(ctx, gameID, bus, timeout, logger, playerCount)
 			// No player publishes an event, simulate a state timeout.
 			Assert(GameDone, game, done, func(states []string) {
 				Expect(states[0]).To(Equal(Init))

--- a/pkg/discovery/game_test.go
+++ b/pkg/discovery/game_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Game", func() {
 		bus = mb.New(10000)
 		timeout = 10 * time.Second
 		gameID = "0"
-		playerCount = 2
+		playerCount = 5
 		game, _ = NewGame(ctx, gameID, bus, timeout, logger, playerCount)
 		pb = Publisher{
 			Bus: bus,
@@ -81,28 +81,39 @@ var _ = Describe("Game", func() {
 			It("transitions to the GameError state", func() {
 				game.Init(errCh)
 				Assert(PlayersReady, game, done, func(states []string) {})
-				pb.Publish(PlayerReady, gameID)
-				pb.Publish(PlayerReady, gameID)
+				for i := 0; i < playerCount; i++ {
+					pb.Publish(PlayerReady, gameID)
+				}
 				WaitDoneOrTimeout(done)
 				Assert(TCPCheckSuccessAll, game, done, func(states []string) {})
-				pb.Publish(TCPCheckSuccess, gameID)
-				pb.Publish(TCPCheckSuccess, gameID)
+				for i := 0; i < playerCount; i++ {
+					pb.Publish(TCPCheckSuccess, gameID)
+				}
 				WaitDoneOrTimeout(done)
 				Assert(GameError, game, done, func(states []string) {})
 				Assert(GameDone, game, done, func(states []string) {
-					Expect(states[0]).To(Equal(Init))
-					Expect(states[1]).To(Equal(WaitPlayersReady))
-					Expect(states[2]).To(Equal(WaitPlayersReady))
-					Expect(states[3]).To(Equal(WaitTCPCheck))
-					Expect(states[4]).To(Equal(WaitTCPCheck))
-					Expect(states[5]).To(Equal(WaitTCPCheck))
-					Expect(states[6]).To(Equal(Playing))
-					Expect(states[7]).To(Equal(Playing))
-					Expect(states[8]).To(Equal(GameError))
-					Expect(states[9]).To(Equal(GameDone))
-					Expect(len(states)).To(Equal(10))
+					statesAsserter := &StatesAsserter{states: states}
+
+					statesAsserter.ExpectNext().To(Equal(Init))
+					for i := 0; i < playerCount; i++ {
+						statesAsserter.ExpectNext().To(Equal(WaitPlayersReady))
+					}
+					statesAsserter.ExpectNext().To(Equal(WaitTCPCheck))
+					for i := 0; i < playerCount; i++ {
+						statesAsserter.ExpectNext().To(Equal(WaitTCPCheck))
+					}
+					for i := 0; i < playerCount; i++ {
+						statesAsserter.ExpectNext().To(Equal(Playing))
+					}
+					statesAsserter.ExpectNext().To(Equal(GameError))
+					statesAsserter.ExpectNext().To(Equal(GameDone))
+
+					Expect(len(states)).To(Equal(3*playerCount + 4))
 				}, ServiceEventsTopic)
-				pb.Publish(GameFinishedWithSuccess, gameID)
+
+				for i := 0; i < playerCount-1; i++ {
+					pb.Publish(GameFinishedWithSuccess, gameID)
+				}
 				pb.Publish(GameFinishedWithError, gameID)
 				WaitDoneOrTimeout(done)
 				WaitDoneOrTimeout(done)
@@ -112,18 +123,24 @@ var _ = Describe("Game", func() {
 			It("transitions to the GameError state", func() {
 				game.Init(errCh)
 				Assert(PlayersReady, game, done, func(states []string) {})
-				pb.Publish(PlayerReady, gameID)
-				pb.Publish(PlayerReady, gameID)
+				for i := 0; i < playerCount; i++ {
+					pb.Publish(PlayerReady, gameID)
+				}
 				WaitDoneOrTimeout(done)
 				Assert(GameDone, game, done, func(states []string) {
-					Expect(states[0]).To(Equal(Init))
-					Expect(states[1]).To(Equal(WaitPlayersReady))
-					Expect(states[2]).To(Equal(WaitPlayersReady))
-					Expect(states[3]).To(Equal(WaitTCPCheck))
-					Expect(states[4]).To(Equal(WaitTCPCheck))
-					Expect(states[5]).To(Equal(GameError))
+					statesAsserter := &StatesAsserter{states: states}
+					statesAsserter.ExpectNext().To(Equal(Init))
+					for i := 0; i < playerCount; i++ {
+						statesAsserter.ExpectNext().To(Equal(WaitPlayersReady))
+					}
+					for i := 0; i < playerCount; i++ {
+						statesAsserter.ExpectNext().To(Equal(WaitTCPCheck))
+					}
+					statesAsserter.ExpectNext().To(Equal(GameError))
 				}, ServiceEventsTopic)
-				pb.Publish(TCPCheckSuccess, gameID)
+				for i := 0; i < playerCount-1; i++ {
+					pb.Publish(TCPCheckSuccess, gameID)
+				}
 				pb.Publish(TCPCheckFailure, gameID)
 				WaitDoneOrTimeout(done)
 			})
@@ -143,3 +160,14 @@ var _ = Describe("Game", func() {
 		})
 	})
 })
+
+type StatesAsserter struct {
+	states       []string
+	currentIndex int
+}
+
+func (s *StatesAsserter) ExpectNext() Assertion {
+	state := s.states[s.currentIndex]
+	s.currentIndex++
+	return Expect(state)
+}

--- a/pkg/discovery/game_test.go
+++ b/pkg/discovery/game_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Game", func() {
 			}
 			WaitDoneOrTimeout(done)
 			Assert(GameDone, game, done, func(states []string) {
-				statesAsserter := &StatesAsserter{states: states}
+				statesAsserter := NewStatesAsserter(states)
 
 				statesAsserter.ExpectNext().To(Equal(Init))
 				for i := 0; i < playerCount; i++ {
@@ -97,7 +97,7 @@ var _ = Describe("Game", func() {
 				WaitDoneOrTimeout(done)
 				Assert(GameError, game, done, func(states []string) {})
 				Assert(GameDone, game, done, func(states []string) {
-					statesAsserter := &StatesAsserter{states: states}
+					statesAsserter := NewStatesAsserter(states)
 
 					statesAsserter.ExpectNext().To(Equal(Init))
 					for i := 0; i < playerCount; i++ {
@@ -133,7 +133,7 @@ var _ = Describe("Game", func() {
 				}
 				WaitDoneOrTimeout(done)
 				Assert(GameDone, game, done, func(states []string) {
-					statesAsserter := &StatesAsserter{states: states}
+					statesAsserter := NewStatesAsserter(states)
 					statesAsserter.ExpectNext().To(Equal(Init))
 					for i := 0; i < playerCount; i++ {
 						statesAsserter.ExpectNext().To(Equal(WaitPlayersReady))
@@ -165,14 +165,3 @@ var _ = Describe("Game", func() {
 		})
 	})
 })
-
-type StatesAsserter struct {
-	states       []string
-	currentIndex int
-}
-
-func (s *StatesAsserter) ExpectNext() Assertion {
-	state := s.states[s.currentIndex]
-	s.currentIndex++
-	return Expect(state)
-}

--- a/pkg/discovery/game_test.go
+++ b/pkg/discovery/game_test.go
@@ -18,25 +18,28 @@ import (
 )
 
 var _ = Describe("Game", func() {
+	generateTestsWithPlayerCount(2)
+	generateTestsWithPlayerCount(5)
+})
+
+func generateTestsWithPlayerCount(playerCount int) {
 	var (
 		done chan struct{}
 		bus  mb.MessageBus
 
-		timeout     time.Duration
-		gameID      string
-		game        *Game
-		playerCount int
-		pb          Publisher
-		errCh       chan error
-		logger      = zap.NewNop().Sugar()
-		ctx         = context.TODO()
+		timeout time.Duration
+		gameID  string
+		game    *Game
+		pb      Publisher
+		errCh   chan error
+		logger  = zap.NewNop().Sugar()
+		ctx     = context.TODO()
 	)
 	BeforeEach(func() {
 		done = make(chan struct{})
 		bus = mb.New(10000)
 		timeout = 10 * time.Second
 		gameID = "0"
-		playerCount = 2
 		game, _ = NewGame(ctx, gameID, bus, timeout, logger, playerCount)
 		pb = Publisher{
 			Bus: bus,
@@ -164,4 +167,4 @@ var _ = Describe("Game", func() {
 			WaitDoneOrTimeout(done)
 		})
 	})
-})
+}

--- a/pkg/discovery/networker.go
+++ b/pkg/discovery/networker.go
@@ -133,7 +133,7 @@ func (i *IstioNetworker) CreateNetwork(pl *pb.Player) (int32, error) {
 			Labels:    lb,
 		},
 		// TODO: remove this 100 hack, it is a temp workaround for protobuf3.
-		Spec: v1alpha1.NetworkSpec{TargetPort: basePort + pl.Id - 100, Port: port},
+		Spec: v1alpha1.NetworkSpec{TargetPort: BasePort + pl.Id - 100, Port: port},
 	}
 	_, err = i.networkingClient.MpcV1alpha1().Networks(defaultNamespace).Create(&network)
 	if err != nil {

--- a/pkg/discovery/test_helpers.go
+++ b/pkg/discovery/test_helpers.go
@@ -111,3 +111,21 @@ func assertExternalEventBody(event *pb.Event, topic string, g *GamesWithBus, don
 		return nil
 	})
 }
+
+// StatesAsserter allows checking for returned states from a Game more easily
+type StatesAsserter struct {
+	states       []string
+	currentIndex int
+}
+
+func NewStatesAsserter(states []string) *StatesAsserter {
+	return &StatesAsserter{
+		states: states,
+	}
+}
+
+func (s *StatesAsserter) ExpectNext() Assertion {
+	state := s.states[s.currentIndex]
+	s.currentIndex++
+	return Expect(state)
+}

--- a/pkg/discovery/test_helpers.go
+++ b/pkg/discovery/test_helpers.go
@@ -118,12 +118,15 @@ type StatesAsserter struct {
 	currentIndex int
 }
 
+// NewStatesAsserter creates a new StatesAsserter that checks the provided states slice
 func NewStatesAsserter(states []string) *StatesAsserter {
 	return &StatesAsserter{
 		states: states,
 	}
 }
 
+// ExpectNext returns an Assertion over the next element of the internal states slice.
+//  This method does not perform any bounds checking, so calling this one time too many will panic
 func (s *StatesAsserter) ExpectNext() Assertion {
 	state := s.states[s.currentIndex]
 	s.currentIndex++

--- a/pkg/ephemeral/fake_spdz_test.go
+++ b/pkg/ephemeral/fake_spdz_test.go
@@ -93,15 +93,15 @@ func (f *FakePlayer) PublishEvent(name, topic string, event *pb.Event) {
 type FakeExecutor struct {
 }
 
-func (f *FakeExecutor) CallCMD(cmd []string, dir string) ([]byte, error) {
-	return []byte{}, nil
+func (f *FakeExecutor) CallCMD(cmd []string, dir string) ([]byte, []byte, error) {
+	return []byte{}, []byte{}, nil
 }
 
 type BrokenFakeExecutor struct {
 }
 
-func (f *BrokenFakeExecutor) CallCMD(cmd []string, dir string) ([]byte, error) {
-	return []byte{}, errors.New("some error")
+func (f *BrokenFakeExecutor) CallCMD(cmd []string, dir string) ([]byte, []byte, error) {
+	return []byte{}, []byte{}, errors.New("some error")
 }
 
 type FakeProxy struct {

--- a/pkg/ephemeral/network/proxy.go
+++ b/pkg/ephemeral/network/proxy.go
@@ -89,7 +89,7 @@ func (p *Proxy) Run(ctx *CtxConfig, errCh chan error) error {
 	return nil
 }
 
-//checkConnectionToPeers verifies that all peers can communicate with each other.
+// checkConnectionToPeers verifies that all peers can communicate with each other.
 // Since the connectivity check requires some Proxy's to be already running, each connection between two parties is only checked one way!
 //
 // This implementation assumes that Proxy.ctx is set.
@@ -98,9 +98,9 @@ func (p *Proxy) checkConnectionToPeers() error {
 	var waitGroup sync.WaitGroup
 	var errorsCheckingConnection []error
 
-	//Check fully connected Graph, each edge checked once
-	//Player i connects to all in [i+1, N]
-	//Assumes that ctx.ProxyEntries is sorted by PlayerId
+	// Check fully connected Graph, each edge checked once
+	// Player i connects to all in [i+1, N]
+	// Assumes that ctx.ProxyEntries is sorted by PlayerId
 	for _, proxyEntry := range p.ctx.ProxyEntries[p.ctx.Spdz.PlayerID:] {
 		proxyEntry := proxyEntry
 		waitGroup.Add(1)
@@ -113,7 +113,7 @@ func (p *Proxy) checkConnectionToPeers() error {
 		}()
 	}
 
-	//Wait for all proxy connections to be completed
+	// Wait for all proxy connections to be completed
 	waitGroup.Wait()
 
 	if len(errorsCheckingConnection) > 0 {

--- a/pkg/ephemeral/network/proxy.go
+++ b/pkg/ephemeral/network/proxy.go
@@ -67,7 +67,7 @@ func (p *Proxy) Run(ctx *CtxConfig, errCh chan error) error {
 		return err
 	}
 
-	p.logger.Info("Starting TCP Proxy")
+	p.logger.Infow("Starting TCP Proxy", GameID, ctx.Act.GameID)
 	go func() {
 		err := p.proxy.Run()
 		errCh <- err

--- a/pkg/ephemeral/network/proxy.go
+++ b/pkg/ephemeral/network/proxy.go
@@ -78,14 +78,12 @@ func (p *Proxy) Run(ctx *CtxConfig, errCh chan error) error {
 
 	for i, pat := range pats {
 		localPort := p.ctx.ProxyEntries[i].LocalPort
-
 		p.logger.Info(fmt.Sprintf("Waiting until proxyEntry is started for local Port %s", localPort))
 		_, err := pat.WaitUntilStarted("", localPort, timeout, dialer)
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -121,7 +119,6 @@ func (p *Proxy) checkConnectionToPeers() error {
 		p.logger.Errorw(message, "errors", errorsCheckingConnection)
 		return errors.New(message)
 	}
-
 	return nil
 }
 

--- a/pkg/ephemeral/network/proxy_test.go
+++ b/pkg/ephemeral/network/proxy_test.go
@@ -31,10 +31,12 @@ var _ = Describe("Proxy", func() {
 				Act: &Activation{
 					GameID: "a",
 				},
-				Proxy: &ProxyConfig{
-					Host:      "localhost",
-					Port:      "5001",
-					LocalPort: "5000",
+				ProxyEntries: []*ProxyConfig{
+					{
+						Host:      "localhost",
+						Port:      "5001",
+						LocalPort: "5000", //ToDo: Switch to ports that are NOT used by everyone else
+					},
 				},
 				Spdz: spdzConfig,
 			}

--- a/pkg/ephemeral/network/proxy_test.go
+++ b/pkg/ephemeral/network/proxy_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Proxy", func() {
 					{
 						Host:      "localhost",
 						Port:      "5001",
-						LocalPort: "5000", //ToDo: Switch to ports that are NOT used by everyone else
+						LocalPort: "5000",
 					},
 				},
 				Spdz: spdzConfig,

--- a/pkg/ephemeral/network/tcpchecker.go
+++ b/pkg/ephemeral/network/tcpchecker.go
@@ -51,12 +51,13 @@ type TCPChecker struct {
 
 // Verify checks network connectivity between the players and communicates its results to discovery and players FSM.
 // Note: since we only support 2 players for now, the check is done only on the first player.
+// ToDo: 2+ Players
 func (t *TCPChecker) Verify(host, port string) error {
 	done := time.After(t.conf.RetryTimeout)
 	for {
 		select {
 		case <-done:
-			return fmt.Errorf("TCPCheck failed after %s and %d attempts", t.conf.RetryTimeout.String(), t.retries)
+			return fmt.Errorf("TCPCheck for '%s:%s' failed after %s and %d attempts", host, port, t.conf.RetryTimeout.String(), t.retries)
 		default:
 			if t.tryToConnect(host, port) {
 				return nil

--- a/pkg/ephemeral/network/tcpchecker.go
+++ b/pkg/ephemeral/network/tcpchecker.go
@@ -50,8 +50,6 @@ type TCPChecker struct {
 }
 
 // Verify checks network connectivity between the players and communicates its results to discovery and players FSM.
-// Note: since we only support 2 players for now, the check is done only on the first player.
-// ToDo: 2+ Players
 func (t *TCPChecker) Verify(host, port string) error {
 	done := time.After(t.conf.RetryTimeout)
 	for {

--- a/pkg/ephemeral/server.go
+++ b/pkg/ephemeral/server.go
@@ -339,10 +339,8 @@ func (p *PlayerWithIO) Start() {
 
 func (s *Server) getPodName() (string, error) {
 	// TODO: this is brittle, read the pod name from more reliable place.
+	//       use something like os.Getenv("HOST_NAME")?
 	cmder := s.executor
-
-	//use something like os.Getenv("HOST_NAME")?
-
 	name, _, err := cmder.CallCMD([]string{"hostname"}, "/")
 	if err != nil {
 		return "", err

--- a/pkg/ephemeral/server.go
+++ b/pkg/ephemeral/server.go
@@ -150,7 +150,6 @@ func (s *Server) BodyFilter(next http.Handler) http.Handler {
 				}
 			}
 		}
-
 		con := context.Background()
 		ctx := &CtxConfig{
 			Act:  &act,

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -63,9 +63,9 @@ type SPDZWrapper struct {
 
 // Execute runs the MPC computation.
 func (s *SPDZWrapper) Execute(event *pb.Event) error {
-	entries, err2 := s.getProxyEntries(event.Players)
-	if err2 != nil {
-		return err2
+	entries, err := s.getProxyEntries(event.Players)
+	if err != nil {
+		return err
 	}
 
 	s.ctx.ProxyEntries = entries
@@ -118,19 +118,7 @@ func (s *SPDZWrapper) getProxyEntries(pls []*pb.Player) ([]*ProxyConfig, error) 
 	return proxyEntries, nil
 }
 
-func (s *SPDZWrapper) getPlayerIPsAndPorts(pls []*pb.Player) (string, string, error) {
-	for _, player := range pls {
-		// The port always includes the second player, change it if the number of players > 2.
-		// ToDo: 2+ Players
-		if player.Id-100 == 1 {
-			return player.Ip, strconv.Itoa(int(player.Port)), nil
-		}
-	}
-	return "", "", fmt.Errorf("player with ID %d not found", s.ctx.Spdz.PlayerID)
-}
-
-// getLocalPortForPlayer returns back the port that is set by the proxy.
-// Note, it only works until the ExpectedPlayers is equal to 2.
+// getLocalPortForPlayer returns the port that is set by the proxy.
 func (s *SPDZWrapper) getLocalPortForPlayer(id int32) string {
 	//TODO will this always work?
 	return strconv.Itoa(int(d.BasePort + id))
@@ -260,8 +248,6 @@ func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
 		ctx.ErrCh <- err
 		s.logger.Errorw(err.Error(), GameID, ctx.Act.GameID)
 	}
-	//s.logger.Infow(fmt.Sprintf("===== Begin of stdout from the user container =====\n%s", string(stdout)), GameID, ctx.Act.GameID)
-	//s.logger.Infow("===== End of stdout from the user container =====", GameID, ctx.Act.GameID)
 
 	s.logger.Debugw("Computation finished", GameID, ctx.Act.GameID, "StdErr", string(stderr), "StdOut", string(stdout), "error", err)
 }

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -111,7 +111,6 @@ func (s *SPDZWrapper) getProxyEntries(pls []*pb.Player) ([]*ProxyConfig, error) 
 
 // getLocalPortForPlayer returns the port that is set by the proxy.
 func (s *SPDZWrapper) getLocalPortForPlayer(id int32) string {
-	//TODO will this always work?
 	return strconv.Itoa(int(d.BasePort + id))
 }
 

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -94,7 +94,7 @@ func (s *SPDZWrapper) getProxyEntries(pls []*pb.Player) ([]*ProxyConfig, error) 
 	for _, player := range players {
 		// TODO: remove this 100 hack, it is a temp workaround for protobuf3.
 		// Create proxy entries for all OTHER players
-		if player.Id-100 != s.ctx.Spdz.PlayerID {
+		if (player.Id - 100) != s.ctx.Spdz.PlayerID {
 			proxyEntries = append(proxyEntries, &ProxyConfig{
 				Host:      player.Ip,
 				Port:      strconv.Itoa(int(player.Port)),

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -67,9 +67,7 @@ func (s *SPDZWrapper) Execute(event *pb.Event) error {
 	if err != nil {
 		return err
 	}
-
 	s.ctx.ProxyEntries = entries
-
 	s.ctx.ErrCh = s.errCh
 	s.logger.Debug("Starting MPC execution")
 	res, err := s.activate(s.ctx)
@@ -83,19 +81,15 @@ func (s *SPDZWrapper) Execute(event *pb.Event) error {
 }
 
 func (s *SPDZWrapper) getProxyEntries(pls []*pb.Player) ([]*ProxyConfig, error) {
-
 	if len(pls) == 1 {
 		return nil, errors.New("you must provide at least two players")
 	}
-
 	// Copy to new Slice so that we don't modify the original Slice (just in case)
 	players := make([]*pb.Player, len(pls))
 	copy(players, pls)
-
 	sort.Slice(players, func(left, right int) bool {
 		return players[left].Id < players[right].Id
 	})
-
 	var proxyEntries []*ProxyConfig
 	for _, player := range players {
 		// TODO: remove this 100 hack, it is a temp workaround for protobuf3.
@@ -108,13 +102,10 @@ func (s *SPDZWrapper) getProxyEntries(pls []*pb.Player) ([]*ProxyConfig, error) 
 			})
 		}
 	}
-
 	s.logger.Infow("Created ProxyEntries", "ProxyEntries", proxyEntries, "Players", players)
-
 	if len(proxyEntries) != len(players)-1 {
 		return nil, errors.New("could not get all ProxyEntries")
 	}
-
 	return proxyEntries, nil
 }
 
@@ -217,17 +208,13 @@ func (s *SPDZEngine) Compile(ctx *CtxConfig) error {
 	if err != nil {
 		return err
 	}
-
 	var stdoutSlice []byte
 	var stderrSlice []byte
-
 	command := fmt.Sprintf("./compile.py %s", appName)
 	stdoutSlice, stderrSlice, err = s.cmder.CallCMD([]string{command}, s.baseDir)
-
 	stdOut := string(stdoutSlice)
 	stdErr := string(stderrSlice)
 	s.logger.Debugw("Compiled Successfully", "Command", command, "StdOut", stdOut, "StdErr", stdErr)
-
 	if err != nil {
 		return err
 	}
@@ -248,7 +235,6 @@ func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
 		ctx.ErrCh <- err
 		s.logger.Errorw(err.Error(), GameID, ctx.Act.GameID)
 	}
-
 	s.logger.Debugw("Computation finished", GameID, ctx.Act.GameID, "StdErr", string(stderr), "StdOut", string(stdout), "error", err)
 }
 
@@ -258,8 +244,6 @@ func (s *SPDZEngine) writeIPFile(path string, addr string, parties int32) error 
 		addrs = addrs + fmt.Sprintf("%s\n", addr)
 	}
 	data := []byte(addrs)
-
 	s.logger.Infow("Writing to IPFile: ", "path", path, "content", addrs, "proxy address", addr, "parties", parties)
-
 	return ioutil.WriteFile(path, data, 0644)
 }

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -13,6 +13,7 @@ import (
 	"github.com/carbynestack/ephemeral/pkg/ephemeral/network"
 	. "github.com/carbynestack/ephemeral/pkg/types"
 	. "github.com/carbynestack/ephemeral/pkg/utils"
+	"sort"
 
 	"errors"
 	"fmt"
@@ -62,13 +63,13 @@ type SPDZWrapper struct {
 
 // Execute runs the MPC computation.
 func (s *SPDZWrapper) Execute(event *pb.Event) error {
-	ip, port, err := s.getPlayerIPAndPort(event.Players)
-	if err != nil {
-		return err
+	entries, err2 := s.getProxyEntries(event.Players)
+	if err2 != nil {
+		return err2
 	}
-	s.ctx.Proxy.Host = ip
-	s.ctx.Proxy.Port = port
-	s.ctx.Proxy.LocalPort = s.getPort(s.ctx.Spdz.PlayerID)
+
+	s.ctx.ProxyEntries = entries
+
 	s.ctx.ErrCh = s.errCh
 	s.logger.Debug("Starting MPC execution")
 	res, err := s.activate(s.ctx)
@@ -81,9 +82,46 @@ func (s *SPDZWrapper) Execute(event *pb.Event) error {
 	return err
 }
 
-func (s *SPDZWrapper) getPlayerIPAndPort(pls []*pb.Player) (string, string, error) {
+func (s *SPDZWrapper) getProxyEntries(pls []*pb.Player) ([]*ProxyConfig, error) {
+
+	if len(pls) == 1 {
+		return nil, errors.New("you must provide at least two players")
+	}
+
+	// Copy to new Slice so that we don't modify the original Slice (just in case)
+	players := make([]*pb.Player, len(pls))
+	copy(players, pls)
+
+	sort.Slice(players, func(left, right int) bool {
+		return players[left].Id < players[right].Id
+	})
+
+	var proxyEntries []*ProxyConfig
+	for _, player := range players {
+		// TODO: remove this 100 hack, it is a temp workaround for protobuf3.
+		// Create proxy entries for all OTHER players
+		if player.Id-100 != s.ctx.Spdz.PlayerID {
+			proxyEntries = append(proxyEntries, &ProxyConfig{
+				Host:      player.Ip,
+				Port:      strconv.Itoa(int(player.Port)),
+				LocalPort: s.getLocalPortForPlayer(player.Id - 100),
+			})
+		}
+	}
+
+	s.logger.Infow("Created ProxyEntries", "ProxyEntries", proxyEntries, "Players", players)
+
+	if len(proxyEntries) != len(players)-1 {
+		return nil, errors.New("could not get all ProxyEntries")
+	}
+
+	return proxyEntries, nil
+}
+
+func (s *SPDZWrapper) getPlayerIPsAndPorts(pls []*pb.Player) (string, string, error) {
 	for _, player := range pls {
 		// The port always includes the second player, change it if the number of players > 2.
+		// ToDo: 2+ Players
 		if player.Id-100 == 1 {
 			return player.Ip, strconv.Itoa(int(player.Port)), nil
 		}
@@ -91,13 +129,11 @@ func (s *SPDZWrapper) getPlayerIPAndPort(pls []*pb.Player) (string, string, erro
 	return "", "", fmt.Errorf("player with ID %d not found", s.ctx.Spdz.PlayerID)
 }
 
-// getPort returns back the port that is set by the proxy.
+// getLocalPortForPlayer returns back the port that is set by the proxy.
 // Note, it only works until the ExpectedPlayers is equal to 2.
-func (s *SPDZWrapper) getPort(id int32) string {
-	if id == 0 {
-		return "5001"
-	}
-	return "5000"
+func (s *SPDZWrapper) getLocalPortForPlayer(id int32) string {
+	//TODO will this always work?
+	return strconv.Itoa(int(d.BasePort + id))
 }
 
 // NewSPDZEngine returns a new instance of SPDZ engine that knows how to compile and trigger an execution of SPDZ runtime.
@@ -154,7 +190,7 @@ func (s *SPDZEngine) Activate(ctx *CtxConfig) ([]byte, error) {
 			s.proxy.Stop()
 		}
 	}()
-	err = s.writeIPFile(s.ipFile, proxyAddress, d.ExpectedPlayers)
+	err = s.writeIPFile(s.ipFile, proxyAddress, ctx.Spdz.PlayerCount)
 	if err != nil {
 		msg := "error due to writing to the ip file"
 		s.logger.Errorw(msg, GameID, act.GameID)
@@ -193,7 +229,17 @@ func (s *SPDZEngine) Compile(ctx *CtxConfig) error {
 	if err != nil {
 		return err
 	}
-	_, err = s.cmder.CallCMD([]string{fmt.Sprintf("./compile.py %s", appName)}, s.baseDir)
+
+	var stdoutSlice []byte
+	var stderrSlice []byte
+
+	command := fmt.Sprintf("./compile.py %s", appName)
+	stdoutSlice, stderrSlice, err = s.cmder.CallCMD([]string{command}, s.baseDir)
+
+	stdOut := string(stdoutSlice)
+	stdErr := string(stderrSlice)
+	s.logger.Debugw("Compiled Successfully", "Command", command, "StdOut", stdOut, "StdErr", stdErr)
+
 	if err != nil {
 		return err
 	}
@@ -206,15 +252,18 @@ func (s *SPDZEngine) getFeedPort() string {
 }
 
 func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
-	s.logger.Infow("Starting Player-Online.x", GameID, ctx.Act.GameID)
-	stdout, err := s.cmder.CallCMD([]string{fmt.Sprintf("./Player-Online.x %s %s -N %s --ip-file-name %s", fmt.Sprint(s.config.PlayerID), appName, fmt.Sprint(d.ExpectedPlayers), ipFile)}, s.baseDir)
+	command := []string{fmt.Sprintf("./Player-Online.x %s %s -N %s --ip-file-name %s", fmt.Sprint(s.config.PlayerID), appName, fmt.Sprint(ctx.Spdz.PlayerCount), ipFile)}
+	s.logger.Infow("Starting Player-Online.x", GameID, ctx.Act.GameID, "command", command)
+	stdout, stderr, err := s.cmder.CallCMD(command, s.baseDir)
 	if err != nil {
 		err := fmt.Errorf("error while executing the user code: %v", err)
 		ctx.ErrCh <- err
 		s.logger.Errorw(err.Error(), GameID, ctx.Act.GameID)
 	}
-	s.logger.Infow(fmt.Sprintf("===== Begin of stdout from the user container =====\n%s", string(stdout)), GameID, ctx.Act.GameID)
-	s.logger.Infow("===== End of stdout from the user container =====", GameID, ctx.Act.GameID)
+	//s.logger.Infow(fmt.Sprintf("===== Begin of stdout from the user container =====\n%s", string(stdout)), GameID, ctx.Act.GameID)
+	//s.logger.Infow("===== End of stdout from the user container =====", GameID, ctx.Act.GameID)
+
+	s.logger.Debugw("Computation finished", GameID, ctx.Act.GameID, "StdErr", string(stderr), "StdOut", string(stdout), "error", err)
 }
 
 func (s *SPDZEngine) writeIPFile(path string, addr string, parties int32) error {
@@ -223,5 +272,8 @@ func (s *SPDZEngine) writeIPFile(path string, addr string, parties int32) error 
 		addrs = addrs + fmt.Sprintf("%s\n", addr)
 	}
 	data := []byte(addrs)
+
+	s.logger.Infow("Writing to IPFile: ", "path", path, "content", addrs, "proxy address", addr, "parties", parties)
+
 	return ioutil.WriteFile(path, data, 0644)
 }

--- a/pkg/ephemeral/spdz_test.go
+++ b/pkg/ephemeral/spdz_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Spdz", func() {
 				s := &SPDZEngine{
 					cmder:          &FakeExecutor{},
 					sourceCodePath: fileName,
+					logger:         zap.NewNop().Sugar(),
 				}
 				conf := &CtxConfig{
 					Act: &Activation{
@@ -62,7 +63,7 @@ var _ = Describe("Spdz", func() {
 				}
 				err := s.Compile(conf)
 				Expect(err).NotTo(HaveOccurred())
-				out, err := cmder.CallCMD([]string{fmt.Sprintf("cat %s", s.sourceCodePath)}, "./")
+				out, _, err := cmder.CallCMD([]string{fmt.Sprintf("cat %s", s.sourceCodePath)}, "./")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(out)).To(Equal("a"))
 			})
@@ -87,6 +88,7 @@ var _ = Describe("Spdz", func() {
 				s := &SPDZEngine{
 					cmder:          &BrokenFakeExecutor{},
 					sourceCodePath: fileName,
+					logger:         zap.NewNop().Sugar(),
 				}
 				conf := &CtxConfig{
 					Act: &Activation{
@@ -125,6 +127,9 @@ var _ = Describe("Spdz", func() {
 					GameID: "0",
 				},
 				Context: context.TODO(),
+				Spdz: &SPDZEngineTypedConfig{
+					PlayerCount: 2,
+				},
 			}
 		})
 		AfterEach(func() {
@@ -203,7 +208,7 @@ var _ = Describe("Spdz", func() {
 				respCh: respCh,
 				logger: zap.NewNop().Sugar(),
 				ctx: &CtxConfig{
-					Proxy: &ProxyConfig{},
+					ProxyEntries: []*ProxyConfig{{}},
 					Spdz: &SPDZEngineTypedConfig{
 						PlayerID: 0,
 					},
@@ -243,7 +248,7 @@ var _ = Describe("Spdz", func() {
 				}
 				err := w.Execute(event)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("player with ID 0 not found"))
+				Expect(err.Error()).To(Equal("you must provide at least two players"))
 			})
 		})
 		Context("when activation fails", func() {

--- a/pkg/integration/discovery_ephemeral_integration.go
+++ b/pkg/integration/discovery_ephemeral_integration.go
@@ -57,7 +57,8 @@ var _ = Describe("Ephemeral integration test", func() {
 				FreePorts: []int32{30000, 30001, 30002},
 			}
 			cl := &discovery.FakeDClient{}
-			s := discovery.NewServiceNG(bus, pb, stateTimeout, tr, n, frontendAddress, logger, ModeMaster, cl)
+			playerCount := 2
+			s := discovery.NewServiceNG(bus, pb, stateTimeout, tr, n, frontendAddress, logger, ModeMaster, cl, playerCount)
 			go s.Start()
 			s.WaitUntilReady(5 * time.Second)
 

--- a/pkg/integration/discovery_ephemeral_integration.go
+++ b/pkg/integration/discovery_ephemeral_integration.go
@@ -66,11 +66,9 @@ func generateEphemeralIntegrationTestsWithPlayerCount(playerCount int) {
 			defer s.Stop()
 			go s.Start()
 			s.WaitUntilReady(5 * time.Second)
-
 			act := &Activation{
 				GameID: "0",
 			}
-
 			players := make([]*p.PlayerWithIO, playerCount)
 			for i := 0; i < playerCount; i++ {
 				ctxConf := &CtxConfig{
@@ -81,13 +79,11 @@ func generateEphemeralIntegrationTestsWithPlayerCount(playerCount int) {
 					},
 					Context: context.TODO(),
 				}
-
 				pod := fmt.Sprintf("abc%d", i)
 				player, err := p.NewPlayerWithIO(ctxConf, conf, pod, spdz, errCh, logger)
 				Expect(err).NotTo(HaveOccurred())
 				players[i] = player
 			}
-
 			for _, player := range players {
 				player.Start()
 			}

--- a/pkg/integration/discovery_ephemeral_integration.go
+++ b/pkg/integration/discovery_ephemeral_integration.go
@@ -26,7 +26,11 @@ import (
 const frontendAddress = "23.97.246.132"
 
 var _ = Describe("Ephemeral integration test", func() {
+	generateEphemeralIntegrationTestsWithPlayerCount(2)
+	generateEphemeralIntegrationTestsWithPlayerCount(5)
+})
 
+func generateEphemeralIntegrationTestsWithPlayerCount(playerCount int) {
 	// Please note, this test doesn't require a real k8s cluster with ephemeral, it runs locally.
 	Context("when connecting ephemeral to discovery", func() {
 		It("finishes the game successfully", func() {
@@ -58,8 +62,8 @@ var _ = Describe("Ephemeral integration test", func() {
 				FreePorts: []int32{30000, 30001, 30002, 30003, 30004, 30005},
 			}
 			cl := &discovery.FakeDClient{}
-			playerCount := 5
 			s := discovery.NewServiceNG(bus, pb, stateTimeout, tr, n, frontendAddress, logger, ModeMaster, cl, playerCount)
+			defer s.Stop()
 			go s.Start()
 			s.WaitUntilReady(5 * time.Second)
 
@@ -87,13 +91,12 @@ var _ = Describe("Ephemeral integration test", func() {
 			for _, player := range players {
 				player.Start()
 			}
-
 			for range players {
 				<-doneCh
 			}
 		})
 	})
-})
+}
 
 type FakeSPDZEngine struct {
 	doneCh chan struct{}

--- a/pkg/integration/discovery_master_slave_integration.go
+++ b/pkg/integration/discovery_master_slave_integration.go
@@ -108,6 +108,7 @@ func getDiscovery(port string, logger *zap.SugaredLogger, bus mb.MessageBus, fro
 		Context:    context.TODO(),
 	}
 	cl, _ := c.NewClient(clientConf)
-	s := d.NewServiceNG(bus, pb, stateTimeout, tr, n, frontend, logger, mode, cl)
+	playerCount := 2
+	s := d.NewServiceNG(bus, pb, stateTimeout, tr, n, frontend, logger, mode, cl, playerCount)
 	return s
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -40,6 +40,7 @@ type DiscoveryConfig struct {
 	Port         string `json:"port"`
 	BusSize      int    `json:"busSize"`
 	PortRange    string `json:"portRange"`
+	PlayerCount  int    `json:"playerCount"`
 }
 
 // Activation is an object that is received as an input from the Ephemeral client.
@@ -60,11 +61,11 @@ type ProxyConfig struct {
 
 // CtxConfig contains both execution and platform specific parameters.
 type CtxConfig struct {
-	Act     *Activation
-	Spdz    *SPDZEngineTypedConfig
-	Proxy   *ProxyConfig
-	ErrCh   chan error
-	Context context.Context
+	Act          *Activation
+	Spdz         *SPDZEngineTypedConfig
+	ProxyEntries []*ProxyConfig
+	ErrCh        chan error
+	Context      context.Context
 }
 
 // SPDZEngineConfig is the VPC specific configuration.
@@ -76,6 +77,7 @@ type SPDZEngineConfig struct {
 	AmphoraConfig    AmphoraConfig `json:"amphoraConfig"`
 	FrontendURL      string        `json:"frontendURL"`
 	PlayerID         int32         `json:"playerID"`
+	PlayerCount      int32         `json:"playerCount"`
 	MaxBulkSize      int32         `json:"maxBulkSize"`
 	DiscoveryAddress string        `json:"discoveryAddress"`
 }
@@ -101,6 +103,7 @@ type SPDZEngineTypedConfig struct {
 	RInv             big.Int
 	AmphoraClient    amphora.AbstractClient
 	PlayerID         int32
+	PlayerCount      int32
 	FrontendURL      string
 	MaxBulkSize      int32
 	DiscoveryAddress string

--- a/pkg/utils/os_test.go
+++ b/pkg/utils/os_test.go
@@ -33,7 +33,7 @@ var _ = Describe("OS utils", func() {
 				Command: "bash",
 				Options: []string{"-c"},
 			}
-			resp, err := cmder.Run("echo 1")
+			resp, _, err := cmder.Run("echo 1")
 			Expect(err).To(BeNil())
 			Expect(string(resp)).To(Equal("1\n"))
 		})
@@ -47,7 +47,7 @@ var _ = Describe("OS utils", func() {
 				}
 				rand.Seed(time.Now().UnixNano())
 				random := rand.Int31()
-				resp, err := cmder.Run(fmt.Sprintf("cat /tmp/non-existing-file-%d", random))
+				resp, _, err := cmder.Run(fmt.Sprintf("cat /tmp/non-existing-file-%d", random))
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(Equal("exit status 1"))
 				Expect(resp).NotTo(BeNil())
@@ -59,7 +59,7 @@ var _ = Describe("OS utils", func() {
 					Command: "non-existing-command",
 					Options: []string{"-c"},
 				}
-				resp, err := cmder.Run("some command")
+				resp, _, err := cmder.Run("some command")
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(Equal("exec: \"non-existing-command\": executable file not found in $PATH"))
 				Expect(len(resp)).To(Equal(0))


### PR DESCRIPTION
To use more than 2 players, it's required to create new crypto-material with given number of players e.g. for 3 players. This also means that the base-image of ephemeral needs to be rebuild including the new crypto-material!

The helm chart is using 2 players as a default, so the current deployment stays with 2 players.

requires https://github.com/carbynestack/ephemeral/pull/19