### PR TITLE
Draft: Feature/test/tuple streaming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4 // indirect
+	golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect

--- a/pkg/amphora/client.go
+++ b/pkg/amphora/client.go
@@ -57,7 +57,7 @@ type Client struct {
 
 const secretShareURI = "/intra-vcp/secret-shares"
 
-// GetSecretShare creates a new secret share by sending a POST request against Amphora.
+// GetSecretShare retrieves an existing secret share by sending a GET request against Amphora.
 func (c *Client) GetSecretShare(id string) (SecretShare, error) {
 	var os SecretShare
 	req, err := http.NewRequest(http.MethodGet, c.URL.String()+fmt.Sprintf("%s/%s", secretShareURI, id), nil)

--- a/pkg/castor/client.go
+++ b/pkg/castor/client.go
@@ -71,7 +71,7 @@ func NewCastorClient(u *url.URL) (*Client, error) {
 	return &Client{HTTPClient: httpClient, URL: u}, nil
 }
 
-const tupleURI = "/tuples"
+const tupleURI = "intra-vcp/tuples"
 
 // DownloadTupleFiles retrieves Tuple files by sending a
 func (c *Client) DownloadTupleFiles(requestId uuid.UUID, numberOfTuples int, tupleType InputType) (tupleFiles TupleList, err error) {
@@ -83,7 +83,7 @@ func (c *Client) DownloadTupleFiles(requestId uuid.UUID, numberOfTuples int, tup
 	urlParams.Add("count", strconv.Itoa(numberOfTuples))
 	urlParams.Add("reservationId", requestId.String())
 
-	getObjectListUrl := c.URL
+	getObjectListUrl := *c.URL
 	getObjectListUrl.Path += tupleURI
 	getObjectListUrl.RawQuery = urlParams.Encode()
 	req, err := http.NewRequest(http.MethodGet, getObjectListUrl.String(), nil)
@@ -121,18 +121,20 @@ func (c *Client) doRequest(req *http.Request, expected int) (io.ReadCloser, erro
 	return resp.Body, nil
 }
 
+const tupleBaseFolder = "Player-Data"
+
 func TupleFileNameFor(inputType InputType, threadNumber int, config *types.SPDZEngineTypedConfig) string {
 	switch inputType {
 	case BitGfp:
-		return fmt.Sprintf("%d-p-%d/Bits-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+		return fmt.Sprintf("%s/%d-p-%d/Bits-p-P%d-T%d", tupleBaseFolder, config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
 	case InputMaskGfp:
-		return fmt.Sprintf("%d-p-%d/Inputs-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+		return fmt.Sprintf("%s/%d-p-%d/Inputs-p-P%d-T%d", tupleBaseFolder, config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
 	case InverseTupleGfp:
-		return fmt.Sprintf("%d-p-%d/Inverses-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+		return fmt.Sprintf("%s/%d-p-%d/Inverses-p-P%d-T%d", tupleBaseFolder, config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
 	case SquareTupleGfp:
-		return fmt.Sprintf("%d-p-%d/Squares-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+		return fmt.Sprintf("%s/%d-p-%d/Squares-p-P%d-T%d", tupleBaseFolder, config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
 	case MultiplicationTripleGfp:
-		return fmt.Sprintf("%d-p-%d/Triples-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+		return fmt.Sprintf("%s/%d-p-%d/Triples-p-P%d-T%d", tupleBaseFolder, config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
 	}
 
 	panic("Unknown type for Name " + inputType)

--- a/pkg/castor/client.go
+++ b/pkg/castor/client.go
@@ -1,0 +1,150 @@
+package castor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/asaskevich/govalidator"
+	"github.com/carbynestack/ephemeral/pkg/types"
+	"github.com/google/uuid"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type InputType string
+
+const (
+	BitGfp                   InputType = "BIT_GFP"
+	BitGf2n                            = "BIT_GF2N"
+	InputMaskGfp                       = "INPUT_MASK_GFP"
+	InputMaskGf2n                      = "INPUT_MASK_GF2N"
+	InverseTupleGfp                    = "INVERSE_TUPLE_GFP"
+	InverseTupleGf2n                   = "INVERSE_TUPLE_GF2N"
+	SquareTupleGfp                     = "SQUARE_TUPLE_GFP"
+	SquareTupleGf2n                    = "SQUARE_TUPLE_GF2N"
+	MultiplicationTripleGfp            = "MULTIPLICATION_TRIPLE_GFP"
+	MultiplicationTripleGf2n           = "MULTIPLICATION_TRIPLE_GF2N"
+)
+
+type TupleList struct {
+	TupleCls string     `json:"tupleCls"`
+	Field    TupleField `json:"field"`
+	Tuples   []Tuple    `json:"tuples"`
+}
+
+type TupleField struct {
+	Type        string `json:"@type"`
+	Name        string `json:"name"`
+	ElementSize int    `json:"elementSize"`
+}
+
+type Tuple struct {
+	Type   string        `json:"@type"`
+	Field  TupleField    `json:"field"`
+	Shares []TupleShares `json:"shares"`
+}
+
+type TupleShares struct {
+	Value string `json:"value"`
+	Mac   string `json:"mac"`
+}
+
+type AbstractClient interface {
+	DownloadTupleFiles(requestId uuid.UUID, numberOfTuples int, tupleType InputType) (tupleFiles TupleList, err error)
+}
+
+type Client struct {
+	HTTPClient http.Client
+	URL        *url.URL
+}
+
+// NewCastorClient returns a new Amphora client.
+func NewCastorClient(u *url.URL) (*Client, error) {
+	ok := govalidator.IsURL(u.String())
+	if !ok {
+		return &Client{}, errors.New("invalid Url")
+	}
+	httpClient := http.Client{}
+	return &Client{HTTPClient: httpClient, URL: u}, nil
+}
+
+const tupleURI = "/tuples"
+
+// DownloadTupleFiles retrieves Tuple files by sending a
+func (c *Client) DownloadTupleFiles(requestId uuid.UUID, numberOfTuples int, tupleType InputType) (tupleFiles TupleList, err error) {
+
+	var result TupleList
+
+	urlParams := url.Values{}
+	urlParams.Add("tupletype", string(tupleType))
+	urlParams.Add("count", strconv.Itoa(numberOfTuples))
+	urlParams.Add("reservationId", requestId.String())
+
+	getObjectListUrl := c.URL
+	getObjectListUrl.Path += tupleURI
+	getObjectListUrl.RawQuery = urlParams.Encode()
+	req, err := http.NewRequest(http.MethodGet, getObjectListUrl.String(), nil)
+
+	if err != nil {
+		return result, err
+	}
+
+	body, err := c.doRequest(req, http.StatusOK)
+	if err != nil {
+		return result, err
+	}
+
+	err = json.NewDecoder(body).Decode(&result)
+	if err != nil {
+		return result, fmt.Errorf("castor returned an invalid response body: %s", err)
+	}
+	return result, nil
+}
+
+// doRequest is a helper method that sends an HTTP request, compares the returned response code with expected and
+// does corresponding error handling.
+func (c *Client) doRequest(req *http.Request, expected int) (io.ReadCloser, error) {
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http client failed sending request: %s", err)
+	}
+	if resp.StatusCode != expected {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("server replied with an unexpected response code #%d: %s", resp.StatusCode, string(bodyBytes))
+	}
+	return resp.Body, nil
+}
+
+func TupleFileNameFor(inputType InputType, threadNumber int, config *types.SPDZEngineTypedConfig) string {
+	switch inputType {
+	case BitGfp:
+		return fmt.Sprintf("%d-p-%d/Bits-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+	case InputMaskGfp:
+		return fmt.Sprintf("%d-p-%d/Inputs-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+	case InverseTupleGfp:
+		return fmt.Sprintf("%d-p-%d/Inverses-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+	case SquareTupleGfp:
+		return fmt.Sprintf("%d-p-%d/Squares-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+	case MultiplicationTripleGfp:
+		return fmt.Sprintf("%d-p-%d/Triples-p-P%d-T%d", config.PlayerCount, config.Prime.BitLen(), config.PlayerID, threadNumber)
+	}
+
+	panic("Unknown type for Name " + inputType)
+}
+
+func ProtocolDescriptorFor(inputType InputType) string {
+	switch inputType {
+	case BitGfp, MultiplicationTripleGfp, InputMaskGfp, InverseTupleGfp, SquareTupleGfp:
+		return "SPDZ gfp"
+	case InputMaskGf2n, InverseTupleGf2n, SquareTupleGf2n, MultiplicationTripleGf2n, BitGf2n:
+		return "SPDZ gf2n"
+	}
+
+	panic("Unknown type for Descriptor " + inputType)
+}

--- a/pkg/ephemeral/io/carrier.go
+++ b/pkg/ephemeral/io/carrier.go
@@ -89,7 +89,7 @@ func (c Carrier) readPrime() error {
 	if err != nil {
 		return err
 	}
-	//ToDo, compare read PRIME with prime number from config?
+	//ToDo, compare read PRIME with Prime number from config?
 	return nil
 }
 

--- a/pkg/ephemeral/io/tuple_provider.go
+++ b/pkg/ephemeral/io/tuple_provider.go
@@ -1,0 +1,199 @@
+package io
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/carbynestack/ephemeral/pkg/castor"
+	"github.com/carbynestack/ephemeral/pkg/types"
+	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
+	"math/big"
+	"net/url"
+	"os"
+	"time"
+)
+
+// TupleProvider writes Tuples to named Pipes
+type TupleProvider interface {
+	StartWritingToFiles() error
+	StopWritingToFiles()
+}
+
+type TupleProviderImpl struct {
+	InputTypes      []castor.InputType
+	NumberOfThreads int
+	config          *types.SPDZEngineTypedConfig
+
+	cancelFunc context.CancelFunc
+
+	castorClient castor.AbstractClient
+}
+
+func NewTupleProvider(inputTypes []castor.InputType, numberOfThreads int, config *types.SPDZEngineTypedConfig, castorUrl *url.URL) *TupleProviderImpl {
+	client, _ := castor.NewCastorClient(castorUrl)
+	return &TupleProviderImpl{
+		InputTypes:      inputTypes,
+		NumberOfThreads: numberOfThreads,
+		config:          config,
+		castorClient:    client,
+	}
+}
+
+func (t *TupleProviderImpl) StartWritingToFiles() error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.cancelFunc = cancelFunc
+
+	for threadNumber := 0; threadNumber < t.NumberOfThreads; threadNumber++ {
+		for _, inputType := range t.InputTypes {
+			writer := newTupleFileWriter(threadNumber, inputType, t.castorClient, t.config)
+			if err := writer.startWritingToFile(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *TupleProviderImpl) StopWritingToFiles() {
+	t.cancelFunc()
+}
+
+type tuplePipeWriter struct {
+	threadNumber                   int
+	inputType                      castor.InputType
+	file                           *os.File
+	config                         *types.SPDZEngineTypedConfig
+	cache                          []byte
+	indexAtCache                   int
+	requestCounter                 int
+	numberOfTuplesToDownloadAtOnce int
+	castorClient                   castor.AbstractClient
+}
+
+func newTupleFileWriter(threadNumber int, inputType castor.InputType, castorClient castor.AbstractClient, config *types.SPDZEngineTypedConfig) tuplePipeWriter {
+	return tuplePipeWriter{
+		threadNumber: threadNumber,
+		inputType:    inputType,
+		castorClient: castorClient,
+		cache:        generateHeader(inputType, &config.Prime),
+		config:       config,
+	}
+}
+
+func generateHeader(inputType castor.InputType, prime *big.Int) []byte {
+	descriptor := []byte(castor.ProtocolDescriptorFor(inputType))
+	lengthOfDescriptor := len(descriptor)
+
+	totalSizeInBytes := uint64(8 + lengthOfDescriptor + 1 + 4 + 16)
+
+	var result []byte
+
+	bytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bytes, totalSizeInBytes)
+	result = append(result, bytes...)
+	result = append(result, descriptor...)
+
+	bytes = make([]byte, 4)
+	binary.LittleEndian.PutUint32(bytes, uint32(prime.BitLen()))
+	result = append(result, bytes...)
+
+	return append(result, prime.Bytes()...)
+}
+
+func (t *tuplePipeWriter) startWritingToFile(ctx context.Context) error {
+	fileName := castor.TupleFileNameFor(t.inputType, t.threadNumber, t.config)
+
+	err := unix.Mkfifo(fileName, 0666)
+	if err != nil {
+		return err
+	}
+
+	t.file, err = os.OpenFile(fileName, os.O_WRONLY, os.ModeNamedPipe)
+	if err != nil {
+		return err
+	}
+
+	err = t.file.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				_ = t.file.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				t.writeToFile()
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (t *tuplePipeWriter) writeToFile() {
+
+	t.updateCacheAndIndex()
+	t.fetchTuplesIfNeeded()
+
+	write, err := t.file.Write(t.cache)
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+	}
+	t.indexAtCache = write
+}
+
+func (t *tuplePipeWriter) updateCacheAndIndex() {
+	if t.indexAtCache == 0 {
+		return
+	}
+
+	if t.cache == nil {
+		t.cache = make([]byte, 0)
+		t.indexAtCache = 0
+	} else {
+		t.cache = t.cache[t.indexAtCache:]
+		t.indexAtCache = 0
+	}
+}
+
+func (t *tuplePipeWriter) fetchTuplesIfNeeded() {
+	if len(t.cache) > 0 {
+		return
+	}
+
+	requestName := fmt.Sprintf("%d-%s-%d", t.threadNumber, t.inputType, t.requestCounter)
+	t.requestCounter++
+	requestId := uuid.NewMD5(uuid.Nil, []byte(requestName))
+	files, err := t.castorClient.DownloadTupleFiles(requestId, t.numberOfTuplesToDownloadAtOnce, t.inputType)
+	t.cache = t.convertResult(files)
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+	}
+}
+
+func (t *tuplePipeWriter) convertResult(files castor.TupleList) []byte {
+	var result []byte
+
+	var b64 []string
+	for _, tuple := range files.Tuples {
+		for _, share := range tuple.Shares {
+			b64 = append(b64, share.Value)
+			b64 = append(b64, share.Mac)
+		}
+	}
+
+	packer := SPDZPacker{
+		MaxBulkSize: 10000,
+	}
+	err := packer.Marshal(b64, &result)
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+	}
+
+	return result
+}

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -231,6 +231,8 @@ func (s *SPDZEngine) getFeedPort() string {
 }
 
 func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
+	// ToDo: Which TupleTypes do we need to support?
+	//       Will there be any non-prime (like GF2N)?
 	inputTypes := []castor.InputType{
 		castor.BitGfp,
 		castor.InputMaskGfp,
@@ -238,7 +240,11 @@ func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
 		castor.SquareTupleGfp,
 		castor.MultiplicationTripleGfp,
 	}
+	// ToDo: How do we know how many threads we will have?
+	//       Alternatively, an upper-Bound would work as well (how many threads will be supported at max).
 	numberOfThreads := 1
+
+	// ToDo: Add read from config File
 	castorUrl, _ := url.Parse("http://cs-castor:10100")
 
 	provider := NewTupleProvider(inputTypes, numberOfThreads, ctx.Spdz, castorUrl, uuid.MustParse(ctx.Act.GameID))

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -15,6 +15,7 @@ import (
 	"github.com/carbynestack/ephemeral/pkg/ephemeral/network"
 	. "github.com/carbynestack/ephemeral/pkg/types"
 	. "github.com/carbynestack/ephemeral/pkg/utils"
+	"github.com/google/uuid"
 	"net/url"
 
 	"errors"
@@ -231,13 +232,16 @@ func (s *SPDZEngine) getFeedPort() string {
 
 func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
 	inputTypes := []castor.InputType{
+		castor.BitGfp,
 		castor.InputMaskGfp,
+		castor.InverseTupleGfp,
+		castor.SquareTupleGfp,
 		castor.MultiplicationTripleGfp,
 	}
 	numberOfThreads := 1
 	castorUrl, _ := url.Parse("http://cs-castor:10100")
 
-	provider := NewTupleProvider(inputTypes, numberOfThreads, ctx.Spdz, castorUrl)
+	provider := NewTupleProvider(inputTypes, numberOfThreads, ctx.Spdz, castorUrl, uuid.MustParse(ctx.Act.GameID))
 
 	err := provider.StartWritingToFiles(ctx.Context)
 	if err != nil {

--- a/pkg/ephemeral/spdz.go
+++ b/pkg/ephemeral/spdz.go
@@ -235,12 +235,16 @@ func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
 		castor.MultiplicationTripleGfp,
 	}
 	numberOfThreads := 1
-	castorUrl, _ := url.Parse("")
+	castorUrl, _ := url.Parse("http://cs-castor:10100")
 
 	provider := NewTupleProvider(inputTypes, numberOfThreads, ctx.Spdz, castorUrl)
-	_ = provider.StartWritingToFiles()
 
-	command := []string{fmt.Sprintf("./Player-Online.x %s %s -N %s --ip-file-name %s", fmt.Sprint(s.config.PlayerID), appName, fmt.Sprint(ctx.Spdz.PlayerCount), ipFile)}
+	err := provider.StartWritingToFiles(ctx.Context)
+	if err != nil {
+		s.logger.Errorw("Error from starting writing to files!", "error", err)
+	}
+
+	command := []string{fmt.Sprintf("./Player-Online.x %s %s -N %s --ip-file-name %s -f", fmt.Sprint(s.config.PlayerID), appName, fmt.Sprint(ctx.Spdz.PlayerCount), ipFile)}
 	s.logger.Infow("Starting Player-Online.x", GameID, ctx.Act.GameID, "command", command)
 	stdout, stderr, err := s.cmder.CallCMD(ctx.Context, command, s.baseDir)
 	if err != nil {
@@ -253,7 +257,6 @@ func (s *SPDZEngine) startMPC(ctx *CtxConfig) {
 	//s.logger.Infow(fmt.Sprintf("===== Begin of stdout from the user container =====\n%s", string(stdout)), GameID, ctx.Act.GameID)
 	//s.logger.Infow("===== End of stdout from the user container =====", GameID, ctx.Act.GameID)
 
-	provider.StopWritingToFiles()
 	s.logger.Debugw("Computation finished", GameID, ctx.Act.GameID, "StdErr", string(stderr), "StdOut", string(stdout), "error", err)
 }
 


### PR DESCRIPTION
This is a test for fetching tuples from Castor (see #6)
It kind of requires the Latest Version of Castor (the changes in Reservation handling carbynestack/castor#29)
-> Otherwise it would at times have errors with relaying the reservation to the castor slave
-> With the current Castor Master, the error was gone ^^


This PR is not ready for production in any way but is rather intended as a first step for further work ^^  
--> Deliberatly not signed-off
- It contains quite a lot of TODO comments
- It also hardcodes some values



How this works:

- Before starting the MP-SPDZ execution, it will create Named Pipes/FIFOs  
  (using the unix package, so on windows this would not work, though I don't think that's a show-stopper)
- Will start 1 Gothread per TupleType and MP-SPDZ VM Thread (currently only tested with 1 thread!)
   - Each thread will write to 1 pipe
   - Starting with the MP-SPDZ Header
   - Then fetching X tuples at a time from castor and writing them
   - Until the context is closed

Does NOT really do any proper error handling or logging (latter is just printlns instead of the logger)

Open questions:
1. Should the Prime/Mac value files be written to by ephemeral, or should they remain part of the base-image?
2. Where do we get information about how many threads are needed for the computation?
3. Which Tuple types are currently supported by CarbyneStack? Castor knows about GFP and GF2N tuples.



Example with Millionaires Problem:
Logs from apollo for this single computation can be found here (not inlined since they are quite big ^^)
https://gist.github.com/kindlich/82ee7b34207a0efb025fb51b4d29e4e9


Before
```
java -jar cache/cli/cs.jar --config-file cache/cli/config.json castor get-telemetry 1
Initializing ExecutorService
bit_gfp
        available:      99640
        consumption/s:  0

inputmask_gfp
        available:      299999
        consumption/s:  0

inversetuple_gfp
        available:      99540
        consumption/s:  0

multiplicationtriple_gfp
        available:      99360
        consumption/s:  0

interval: 60000
```

Run like normal (in my case with a helper-script)
```
./scripts/execute-ephemeral.sh ../carbyne/mpc-evaluation/mp-spdz/Programs/Source/cb-billionaires.mpc -i $SECRET_A -i $SECRET_A 
d76d967c-da5d-4090-bd03-cb5fa560cf97
```

After
```
Initializing ExecutorService
bit_gfp
        available:      99280
        consumption/s:  0

inputmask_gfp
        available:      299999
        consumption/s:  0

inversetuple_gfp
        available:      99540
        consumption/s:  0

multiplicationtriple_gfp
        available:      99210
        consumption/s:  0

interval: 60000
```