### PR TITLE
upgrade apiextensions.k8s.io version to v1 from beta1

### DIFF
--- a/charts/ephemeral/templates/mpc-network-crd.yaml
+++ b/charts/ephemeral/templates/mpc-network-crd.yaml
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networks.mpc.bosch.com
@@ -16,23 +16,26 @@ spec:
     plural: networks
     singular: network
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-        status:
-          type: object
-  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+              spec:
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                  status:
+                    type: object


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22.

    Migrate manifests and API clients to use the apiextensions.k8s.io/v1 API version, available since v1.16.

Signed-off-by: Veselin Vlasakiev <veselin@veselin.org>