### PR TITLE
chore: release  service 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.0",
+  ".": "0.1.1",
   "charts/ephemeral": "0.1.0",
   "ephemeral-java-client": "0.1.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/ephemeral/compare/service-v0.1.0...service-v0.1.1) (2023-07-26)
+
+
+### Bug Fixes
+
+* **service/chart/java-client:** test release logic ([#39](https://github.com/carbynestack/ephemeral/issues/39)) ([9c8f07b](https://github.com/carbynestack/ephemeral/commit/9c8f07b53f7f9792ad2b484b25666c1a4244303d))


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/ephemeral/compare/service-v0.1.0...service-v0.1.1) (2023-07-26)


### Bug Fixes

* **service/chart/java-client:** test release logic ([#39](https://github.com/carbynestack/ephemeral/issues/39)) ([9c8f07b](https://github.com/carbynestack/ephemeral/commit/9c8f07b53f7f9792ad2b484b25666c1a4244303d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).