### PR TITLE
chore: release  chart 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.1.0",
-  "charts/ephemeral": "0.1.0",
+  "charts/ephemeral": "0.1.1",
   "ephemeral-java-client": "0.1.0"
 }

--- a/charts/ephemeral/CHANGELOG.md
+++ b/charts/ephemeral/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-26)
+
+
+### Bug Fixes
+
+* **service/chart/java-client:** test release logic ([#39](https://github.com/carbynestack/ephemeral/issues/39)) ([9c8f07b](https://github.com/carbynestack/ephemeral/commit/9c8f07b53f7f9792ad2b484b25666c1a4244303d))

--- a/charts/ephemeral/Chart.yaml
+++ b/charts/ephemeral/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Carbyne Stack Ephemeral service.
 name: ephemeral
-version: 0.2.0
+version: 0.1.1
 keywords:
   - carbyne stack
   - ephemeral


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-26)


### Bug Fixes

* **service/chart/java-client:** test release logic ([#39](https://github.com/carbynestack/ephemeral/issues/39)) ([9c8f07b](https://github.com/carbynestack/ephemeral/commit/9c8f07b53f7f9792ad2b484b25666c1a4244303d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).