### PR TITLE
chore: release  chart 0.1.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.1.1",
-  "charts/ephemeral": "0.1.1",
+  "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.1"
 }

--- a/charts/ephemeral/CHANGELOG.md
+++ b/charts/ephemeral/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.2](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.1...chart-v0.1.2) (2023-07-26)
+
+
+### Bug Fixes
+
+* **service/chart/java-client:** test release logic with some minor fixes ([#46](https://github.com/carbynestack/ephemeral/issues/46)) ([a215b6b](https://github.com/carbynestack/ephemeral/commit/a215b6b884ea73fc69f4283aca849dbc8bf520d4))
+
 ## [0.1.1](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-26)
 
 

--- a/charts/ephemeral/Chart.yaml
+++ b/charts/ephemeral/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Carbyne Stack Ephemeral service.
 name: ephemeral
-version: 0.1.1
+version: 0.1.2
 keywords:
   - carbyne stack
   - ephemeral


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.2](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.1...chart-v0.1.2) (2023-07-26)


### Bug Fixes

* **service/chart/java-client:** test release logic with some minor fixes ([#46](https://github.com/carbynestack/ephemeral/issues/46)) ([a215b6b](https://github.com/carbynestack/ephemeral/commit/a215b6b884ea73fc69f4283aca849dbc8bf520d4))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).