### PR TITLE
chore: release  java-client 0.1.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.1.1",
   "charts/ephemeral": "0.1.1",
-  "ephemeral-java-client": "0.1.1"
+  "ephemeral-java-client": "0.1.2"
 }

--- a/ephemeral-java-client/CHANGELOG.md
+++ b/ephemeral-java-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.2](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.1...java-client-v0.1.2) (2023-07-26)
+
+
+### Bug Fixes
+
+* **service/chart/java-client:** test release logic with some minor fixes ([#46](https://github.com/carbynestack/ephemeral/issues/46)) ([a215b6b](https://github.com/carbynestack/ephemeral/commit/a215b6b884ea73fc69f4283aca849dbc8bf520d4))
+
 ## [0.1.1](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.0...java-client-v0.1.1) (2023-07-26)
 
 

--- a/ephemeral-java-client/pom.xml
+++ b/ephemeral-java-client/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ephemeral-java-client</artifactId>
     <groupId>io.carbynestack</groupId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <name>Carbyne Stack Ephemeral Java Client</name>
     <description>Java client for the Carbyne Stack Ephemeral service.</description>
     <licenses>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.2](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.1...java-client-v0.1.2) (2023-07-26)


### Bug Fixes

* **service/chart/java-client:** test release logic with some minor fixes ([#46](https://github.com/carbynestack/ephemeral/issues/46)) ([a215b6b](https://github.com/carbynestack/ephemeral/commit/a215b6b884ea73fc69f4283aca849dbc8bf520d4))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).