### PR TITLE
chore: release  java-client 0.1.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.1.2",
   "charts/ephemeral": "0.1.2",
-  "ephemeral-java-client": "0.1.2"
+  "ephemeral-java-client": "0.1.3"
 }

--- a/ephemeral-java-client/CHANGELOG.md
+++ b/ephemeral-java-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.3](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.2...java-client-v0.1.3) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service/java-client:** add support for partial builds using codeco… ([#52](https://github.com/carbynestack/ephemeral/issues/52)) ([5a7a591](https://github.com/carbynestack/ephemeral/commit/5a7a591c5d81daf8bad09826b9c9f8bfcbe73eee))
+
 ## [0.1.2](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.1...java-client-v0.1.2) (2023-07-26)
 
 

--- a/ephemeral-java-client/pom.xml
+++ b/ephemeral-java-client/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ephemeral-java-client</artifactId>
     <groupId>io.carbynestack</groupId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <name>Carbyne Stack Ephemeral Java Client</name>
     <description>Java client for the Carbyne Stack Ephemeral service.</description>
     <licenses>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.3](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.2...java-client-v0.1.3) (2023-07-27)


### Bug Fixes

* **service/java-client:** add support for partial builds using codeco… ([#52](https://github.com/carbynestack/ephemeral/issues/52)) ([5a7a591](https://github.com/carbynestack/ephemeral/commit/5a7a591c5d81daf8bad09826b9c9f8bfcbe73eee))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).