### PR TITLE
chore: release  service 0.1.5

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.4",
+  ".": "0.1.5",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.5](https://github.com/carbynestack/ephemeral/compare/service-v0.1.4...service-v0.1.5) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service:** fix publish workflow for service ([#57](https://github.com/carbynestack/ephemeral/issues/57)) ([570b6b6](https://github.com/carbynestack/ephemeral/commit/570b6b6a701687aa0d76adfe8b54540f16884cb1))
+
 ## [0.1.4](https://github.com/carbynestack/ephemeral/compare/service-v0.1.3...service-v0.1.4) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.5](https://github.com/carbynestack/ephemeral/compare/service-v0.1.4...service-v0.1.5) (2023-07-27)


### Bug Fixes

* **service:** fix publish workflow for service ([#57](https://github.com/carbynestack/ephemeral/issues/57)) ([570b6b6](https://github.com/carbynestack/ephemeral/commit/570b6b6a701687aa0d76adfe8b54540f16884cb1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).