### PR TITLE
chore: release  service 0.1.6

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.5",
+  ".": "0.1.6",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.6](https://github.com/carbynestack/ephemeral/compare/service-v0.1.5...service-v0.1.6) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service:** add missing '=' when invoking ko ([#59](https://github.com/carbynestack/ephemeral/issues/59)) ([ebe4c84](https://github.com/carbynestack/ephemeral/commit/ebe4c8472a3883917dbc562cc7e571141ca55bd2))
+
 ## [0.1.5](https://github.com/carbynestack/ephemeral/compare/service-v0.1.4...service-v0.1.5) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.6](https://github.com/carbynestack/ephemeral/compare/service-v0.1.5...service-v0.1.6) (2023-07-27)


### Bug Fixes

* **service:** add missing '=' when invoking ko ([#59](https://github.com/carbynestack/ephemeral/issues/59)) ([ebe4c84](https://github.com/carbynestack/ephemeral/commit/ebe4c8472a3883917dbc562cc7e571141ca55bd2))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).