### PR TITLE
chore: release  service 0.1.8

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.7",
+  ".": "0.1.8",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.8](https://github.com/carbynestack/ephemeral/compare/service-v0.1.7...service-v0.1.8) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service:** test without labels ([#63](https://github.com/carbynestack/ephemeral/issues/63)) ([5e1f1fa](https://github.com/carbynestack/ephemeral/commit/5e1f1fa14a7677e93253264bc3ba31a4c569227b))
+
 ## [0.1.7](https://github.com/carbynestack/ephemeral/compare/service-v0.1.6...service-v0.1.7) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.8](https://github.com/carbynestack/ephemeral/compare/service-v0.1.7...service-v0.1.8) (2023-07-27)


### Bug Fixes

* **service:** test without labels ([#63](https://github.com/carbynestack/ephemeral/issues/63)) ([5e1f1fa](https://github.com/carbynestack/ephemeral/commit/5e1f1fa14a7677e93253264bc3ba31a4c569227b))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).