### PR TITLE
chore: release  service 0.1.9

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.8",
+  ".": "0.1.9",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.9](https://github.com/carbynestack/ephemeral/compare/service-v0.1.8...service-v0.1.9) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service:** generate both tags and lables for ko correctly ([#65](https://github.com/carbynestack/ephemeral/issues/65)) ([1ccac01](https://github.com/carbynestack/ephemeral/commit/1ccac012cff5c4ce7bcf4de854515116a872b51c))
+
 ## [0.1.8](https://github.com/carbynestack/ephemeral/compare/service-v0.1.7...service-v0.1.8) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.9](https://github.com/carbynestack/ephemeral/compare/service-v0.1.8...service-v0.1.9) (2023-07-27)


### Bug Fixes

* **service:** generate both tags and lables for ko correctly ([#65](https://github.com/carbynestack/ephemeral/issues/65)) ([1ccac01](https://github.com/carbynestack/ephemeral/commit/1ccac012cff5c4ce7bcf4de854515116a872b51c))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).