### PR TITLE
chore: release  service 0.1.10

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.9",
+  ".": "0.1.10",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.10](https://github.com/carbynestack/ephemeral/compare/service-v0.1.9...service-v0.1.10) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service:** quote labels given to ko ([#67](https://github.com/carbynestack/ephemeral/issues/67)) ([d3bdb0b](https://github.com/carbynestack/ephemeral/commit/d3bdb0b73b390a299b382cc7b2ed0d51ed0c27f4))
+
 ## [0.1.9](https://github.com/carbynestack/ephemeral/compare/service-v0.1.8...service-v0.1.9) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.10](https://github.com/carbynestack/ephemeral/compare/service-v0.1.9...service-v0.1.10) (2023-07-27)


### Bug Fixes

* **service:** quote labels given to ko ([#67](https://github.com/carbynestack/ephemeral/issues/67)) ([d3bdb0b](https://github.com/carbynestack/ephemeral/commit/d3bdb0b73b390a299b382cc7b2ed0d51ed0c27f4))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).