### PR TITLE
chore: release  service 0.1.11

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.10",
+  ".": "0.1.11",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.11](https://github.com/carbynestack/ephemeral/compare/service-v0.1.10...service-v0.1.11) (2023-07-27)
+
+
+### Bug Fixes
+
+* **service:** quote tags and labels argument to make ko working ([#69](https://github.com/carbynestack/ephemeral/issues/69)) ([973f067](https://github.com/carbynestack/ephemeral/commit/973f0673003530aae9a693f0799a6008850b269a))
+
 ## [0.1.10](https://github.com/carbynestack/ephemeral/compare/service-v0.1.9...service-v0.1.10) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.11](https://github.com/carbynestack/ephemeral/compare/service-v0.1.10...service-v0.1.11) (2023-07-27)


### Bug Fixes

* **service:** quote tags and labels argument to make ko working ([#69](https://github.com/carbynestack/ephemeral/issues/69)) ([973f067](https://github.com/carbynestack/ephemeral/commit/973f0673003530aae9a693f0799a6008850b269a))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).