### PR TITLE
chore: release  service 0.1.12

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.11",
+  ".": "0.1.12",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.12](https://github.com/carbynestack/ephemeral/compare/service-v0.1.11...service-v0.1.12) (2023-07-28)
+
+
+### Bug Fixes
+
+* **service:** extract the label part from what is returned by the metadata action ([#71](https://github.com/carbynestack/ephemeral/issues/71)) ([2243f0f](https://github.com/carbynestack/ephemeral/commit/2243f0f113e96925d1ca4e1f3c92bb51914c3e4c))
+
 ## [0.1.11](https://github.com/carbynestack/ephemeral/compare/service-v0.1.10...service-v0.1.11) (2023-07-27)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.12](https://github.com/carbynestack/ephemeral/compare/service-v0.1.11...service-v0.1.12) (2023-07-28)


### Bug Fixes

* **service:** extract the label part from what is returned by the metadata action ([#71](https://github.com/carbynestack/ephemeral/issues/71)) ([2243f0f](https://github.com/carbynestack/ephemeral/commit/2243f0f113e96925d1ca4e1f3c92bb51914c3e4c))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).