### PR TITLE
chore: release  service 0.1.13

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.1.12",
+  ".": "0.1.13",
   "charts/ephemeral": "0.1.2",
   "ephemeral-java-client": "0.1.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.13](https://github.com/carbynestack/ephemeral/compare/service-v0.1.12...service-v0.1.13) (2023-08-04)
+
+
+### Bug Fixes
+
+* **service/chart:** fix forced aborts of long-running computations ([#36](https://github.com/carbynestack/ephemeral/issues/36)) ([a131ae7](https://github.com/carbynestack/ephemeral/commit/a131ae74bd9d98d345d78d84a67388cbd783b36d))
+
 ## [0.1.12](https://github.com/carbynestack/ephemeral/compare/service-v0.1.11...service-v0.1.12) (2023-07-28)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.13](https://github.com/carbynestack/ephemeral/compare/service-v0.1.12...service-v0.1.13) (2023-08-04)


### Bug Fixes

* **service/chart:** fix forced aborts of long-running computations ([#36](https://github.com/carbynestack/ephemeral/issues/36)) ([a131ae7](https://github.com/carbynestack/ephemeral/commit/a131ae74bd9d98d345d78d84a67388cbd783b36d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).