### PR TITLE
chore: release  chart 0.1.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.1.12",
-  "charts/ephemeral": "0.1.2",
+  "charts/ephemeral": "0.1.3",
   "ephemeral-java-client": "0.1.3"
 }

--- a/charts/ephemeral/CHANGELOG.md
+++ b/charts/ephemeral/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.3](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.2...chart-v0.1.3) (2023-08-04)
+
+
+### Bug Fixes
+
+* **service/chart:** fix forced aborts of long-running computations ([#36](https://github.com/carbynestack/ephemeral/issues/36)) ([a131ae7](https://github.com/carbynestack/ephemeral/commit/a131ae74bd9d98d345d78d84a67388cbd783b36d))
+
 ## [0.1.2](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.1...chart-v0.1.2) (2023-07-26)
 
 

--- a/charts/ephemeral/Chart.yaml
+++ b/charts/ephemeral/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Carbyne Stack Ephemeral service.
 name: ephemeral
-version: 0.1.2
+version: 0.1.3
 keywords:
   - carbyne stack
   - ephemeral


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.3](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.2...chart-v0.1.3) (2023-08-04)


### Bug Fixes

* **service/chart:** fix forced aborts of long-running computations ([#36](https://github.com/carbynestack/ephemeral/issues/36)) ([a131ae7](https://github.com/carbynestack/ephemeral/commit/a131ae74bd9d98d345d78d84a67388cbd783b36d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).