### PR TITLE
chore: release  java-client 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.1.13",
   "charts/ephemeral": "0.1.3",
-  "ephemeral-java-client": "0.1.3"
+  "ephemeral-java-client": "0.2.0"
 }

--- a/ephemeral-java-client/CHANGELOG.md
+++ b/ephemeral-java-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.3...java-client-v0.2.0) (2024-10-09)
+
+
+### Features
+
+* **java-client:** upgrade dependencies ([#77](https://github.com/carbynestack/ephemeral/issues/77)) ([4f1d0e8](https://github.com/carbynestack/ephemeral/commit/4f1d0e81ccb11b73cb7d03ccc0f598e58f89678e))
+
 ## [0.1.3](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.2...java-client-v0.1.3) (2023-07-27)
 
 

--- a/ephemeral-java-client/pom.xml
+++ b/ephemeral-java-client/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ephemeral-java-client</artifactId>
     <groupId>io.carbynestack</groupId>
-    <version>0.1.3</version>
+    <version>0.2.0</version>
     <name>Carbyne Stack Ephemeral Java Client</name>
     <description>Java client for the Carbyne Stack Ephemeral service.</description>
     <licenses>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/ephemeral/compare/java-client-v0.1.3...java-client-v0.2.0) (2024-10-09)


### Features

* **java-client:** upgrade dependencies ([#77](https://github.com/carbynestack/ephemeral/issues/77)) ([4f1d0e8](https://github.com/carbynestack/ephemeral/commit/4f1d0e81ccb11b73cb7d03ccc0f598e58f89678e))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).