### PR TITLE
chore: release  service 0.3.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.2.0",
+  ".": "0.3.0",
   "charts/ephemeral": "0.2.0",
   "ephemeral-java-client": "0.2.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0](https://github.com/carbynestack/ephemeral/compare/service-v0.2.0...service-v0.3.0) (2025-03-04)
+
+
+### ⚠ BREAKING CHANGES
+
+* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75))
+
+### Features
+
+* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75)) ([4eb64f7](https://github.com/carbynestack/ephemeral/commit/4eb64f7a7f37e013079eb641660b4288bc5a7c3f))
+
 ## [0.2.0](https://github.com/carbynestack/ephemeral/compare/service-v0.1.13...service-v0.2.0) (2024-12-17)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.0](https://github.com/carbynestack/ephemeral/compare/service-v0.2.0...service-v0.3.0) (2025-03-04)


### ⚠ BREAKING CHANGES

* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75))

### Features

* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75)) ([4eb64f7](https://github.com/carbynestack/ephemeral/commit/4eb64f7a7f37e013079eb641660b4288bc5a7c3f))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).