### PR TITLE
chore: release  chart 0.3.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.2.0",
-  "charts/ephemeral": "0.2.0",
+  "charts/ephemeral": "0.3.0",
   "ephemeral-java-client": "0.2.0"
 }

--- a/charts/ephemeral/CHANGELOG.md
+++ b/charts/ephemeral/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0](https://github.com/carbynestack/ephemeral/compare/chart-v0.2.0...chart-v0.3.0) (2025-03-04)
+
+
+### ⚠ BREAKING CHANGES
+
+* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75))
+
+### Features
+
+* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75)) ([4eb64f7](https://github.com/carbynestack/ephemeral/commit/4eb64f7a7f37e013079eb641660b4288bc5a7c3f))
+
 ## [0.2.0](https://github.com/carbynestack/ephemeral/compare/chart-v0.1.3...chart-v0.2.0) (2024-12-17)
 
 

--- a/charts/ephemeral/Chart.yaml
+++ b/charts/ephemeral/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Carbyne Stack Ephemeral service.
 name: ephemeral
-version: 0.2.0
+version: 0.3.0
 keywords:
   - carbyne stack
   - ephemeral


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.0](https://github.com/carbynestack/ephemeral/compare/chart-v0.2.0...chart-v0.3.0) (2025-03-04)


### ⚠ BREAKING CHANGES

* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75))

### Features

* Secure Communication Channels via TLS ([#75](https://github.com/carbynestack/ephemeral/issues/75)) ([4eb64f7](https://github.com/carbynestack/ephemeral/commit/4eb64f7a7f37e013079eb641660b4288bc5a7c3f))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).