### PR TITLE
chore: release  service 0.3.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "0.3.0",
+  ".": "0.3.1",
   "charts/ephemeral": "0.3.0",
   "ephemeral-java-client": "0.2.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1](https://github.com/carbynestack/ephemeral/compare/service-v0.3.0...service-v0.3.1) (2025-03-18)
+
+
+### Bug Fixes
+
+* **service:** make master port mandatory for slave only ([#86](https://github.com/carbynestack/ephemeral/issues/86)) ([d7ec225](https://github.com/carbynestack/ephemeral/commit/d7ec2255d11fbe2b319151243e150e0a819225d7))
+
 ## [0.3.0](https://github.com/carbynestack/ephemeral/compare/service-v0.2.0...service-v0.3.0) (2025-03-04)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.1](https://github.com/carbynestack/ephemeral/compare/service-v0.3.0...service-v0.3.1) (2025-03-18)


### Bug Fixes

* **service:** make master port mandatory for slave only ([#86](https://github.com/carbynestack/ephemeral/issues/86)) ([d7ec225](https://github.com/carbynestack/ephemeral/commit/d7ec2255d11fbe2b319151243e150e0a819225d7))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).